### PR TITLE
[FEATURE] Added Permission Client  & Respective Test Cases 

### DIFF
--- a/src/story_protocol_python_sdk/resources/Permission.py
+++ b/src/story_protocol_python_sdk/resources/Permission.py
@@ -1,0 +1,85 @@
+# src/story_protcol_python_sdk/resources/Permission.py
+
+from web3 import Web3
+import os, json
+
+from story_protocol_python_sdk.abi.IPAccountImpl.IPAccountImpl_client import IPAccountImplClient
+from story_protocol_python_sdk.utils.transaction_utils import build_and_send_transaction
+
+class Permission:
+    """
+    A class to manage permissions for IP accounts.
+
+    :param web3 Web3: An instance of Web3.
+    :param account: The account to use for transactions.
+    :param chain_id int: The ID of the blockchain network.
+    """
+    def __init__(self, web3: Web3, account, chain_id: int):
+        self.web3 = web3
+        self.account = account
+        self.chain_id = chain_id
+
+    def setPermission(self, ip_asset: str, signer: str, to: str, permission: int, func: str = "0x00000000", tx_options: dict = None) -> dict:
+        """
+        Sets the permission for a specific function call.
+
+        :param ip_asset str: The address of the IP account that grants the permission for `signer`.
+        :param signer str: The address that can call `to` on behalf of the `ip_asset`.
+        :param to str: The address that can be called by the `signer`.
+        :param permission int: The new permission level.
+        :param func str: [Optional] The function selector string of `to` that can be called by the `signer` on behalf of the `ipAccount`.
+        :param tx_options dict: [Optional] The transaction options.
+        :return dict: A dictionary with the transaction hash.
+        """
+        try:
+            if not self.web3.is_address(signer):
+                raise ValueError(f"The address {signer} that can call 'to' on behalf of the 'ip_asset' is not a valid address.")
+
+            if not self.web3.is_address(to):
+                raise ValueError(f"The recipient of the transaction {to} is not a valid address.")
+            
+            if not self._is_registered(ip_asset):
+                raise ValueError(f"The IP account with id {ip_asset} is not registered.")
+
+            ip_account_client = IPAccountImplClient(self.web3, contract_address=ip_asset)
+
+            config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'scripts', 'config.json'))
+            with open(config_path, 'r') as config_file:
+                config = json.load(config_file)
+            contract_address = None
+            for contract in config['contracts']:
+                if contract['contract_name'] == 'AccessController':
+                    contract_address = contract['contract_address']
+                    break
+            if not contract_address:
+                raise ValueError(f"Contract address for AccessController not found in config.json")
+            abi_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'abi', 'AccessController', 'AccessController.json'))
+            with open(abi_path, 'r') as abi_file:
+                abi = json.load(abi_file)
+
+            contract = self.web3.eth.contract(address=contract_address, abi=abi)
+            
+            data = contract.encodeABI(
+                fn_name="setPermission",
+                args=[
+                    ip_asset,
+                    signer,
+                    to,
+                    func,
+                    permission
+                ]
+            )
+
+            response = ip_account_client.execute(
+                 to=contract_address,
+                 value=0,
+                 account_address=ip_asset,
+                 data=data
+            )
+
+            return {
+                'txHash': response['txHash']
+            }
+
+        except Exception as e:
+            raise e

--- a/src/story_protocol_python_sdk/story_client.py
+++ b/src/story_protocol_python_sdk/story_client.py
@@ -13,6 +13,7 @@ from story_protocol_python_sdk.resources.IPAsset import IPAsset
 from story_protocol_python_sdk.resources.License import License
 from story_protocol_python_sdk.resources.Royalty import Royalty
 from story_protocol_python_sdk.resources.IPAccount import IPAccount
+from story_protocol_python_sdk.resources.Permission import Permission
 
 class StoryClient:
     """
@@ -42,6 +43,7 @@ class StoryClient:
         self._license = None
         self._royalty = None
         self._ip_account = None
+        self._permission = None
 
     @property
     def IPAsset(self) -> IPAsset:
@@ -86,3 +88,14 @@ class StoryClient:
         if self._ip_account is None:
             self._ip_account = IPAccount(self.web3, self.account, self.chain_id)
         return self._ip_account
+    
+    @property
+    def Permission(self) -> Permission:
+        """
+        Access the Permission resource.
+
+        :return Permission: An instance of Permission.
+        """
+        if self._permission is None:
+            self._permission = Permission(self.web3, self.account, self.chain_id)
+        return self._permission

--- a/tests/integration/test_integration_permission.py
+++ b/tests/integration/test_integration_permission.py
@@ -4,8 +4,6 @@ import os, json, sys
 import pytest
 from dotenv import load_dotenv
 from web3 import Web3
-from eth_account import Account
-from eth_account.messages import encode_typed_data
 
 # Ensure the src directory is in the Python path
 current_dir = os.path.dirname(__file__)
@@ -13,7 +11,7 @@ src_path = os.path.abspath(os.path.join(current_dir, '..', '..'))
 if src_path not in sys.path:
     sys.path.append(src_path)
 
-from utils import get_token_id, get_story_client_in_sepolia, MockERC721, getBlockTimestamp
+from utils import get_token_id, get_story_client_in_sepolia, MockERC721, check_event_in_tx
 
 load_dotenv()
 private_key = os.getenv('WALLET_PRIVATE_KEY')
@@ -68,3 +66,5 @@ def test_setPermission(story_client):
     assert response['txHash'] is not None, "'txHash' is None."
     assert isinstance(response['txHash'], str), "'txHash' is not a string."
     assert len(response['txHash']) > 0, "'txHash' is empty."
+
+    assert check_event_in_tx(web3, response['txHash'], "PermissionSet(address,address,address,address,bytes4,uint8)") is True

--- a/tests/integration/test_integration_permission.py
+++ b/tests/integration/test_integration_permission.py
@@ -1,0 +1,70 @@
+# tests/integration/test_integration_permission.py
+
+import os, json, sys
+import pytest
+from dotenv import load_dotenv
+from web3 import Web3
+from eth_account import Account
+from eth_account.messages import encode_typed_data
+
+# Ensure the src directory is in the Python path
+current_dir = os.path.dirname(__file__)
+src_path = os.path.abspath(os.path.join(current_dir, '..', '..'))
+if src_path not in sys.path:
+    sys.path.append(src_path)
+
+from utils import get_token_id, get_story_client_in_sepolia, MockERC721, getBlockTimestamp
+
+load_dotenv()
+private_key = os.getenv('WALLET_PRIVATE_KEY')
+rpc_url = os.getenv('RPC_PROVIDER_URL')
+
+# Initialize Web3
+web3 = Web3(Web3.HTTPProvider(rpc_url))
+if not web3.is_connected():
+    raise Exception("Failed to connect to Web3 provider")
+
+# Set up the account with the private key
+account = web3.eth.account.from_key(private_key)
+
+@pytest.fixture
+def story_client():
+    return get_story_client_in_sepolia(web3, account)
+
+def test_setPermission(story_client):
+    config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'story_protocol_python_sdk', 'scripts', 'config.json'))
+    with open(config_path, 'r') as config_file:
+        config = json.load(config_file)
+    contract_address = None
+    for contract in config['contracts']:
+        if contract['contract_name'] == 'AccessController':
+            contract_address = contract['contract_address']
+            break
+    if not contract_address:
+        raise ValueError(f"Contract address for AccessController not found in config.json")
+    abi_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'story_protocol_python_sdk', 'abi', 'AccessController', 'AccessController.json'))
+    with open(abi_path, 'r') as abi_file:
+        abi = json.load(abi_file)
+
+    contract = web3.eth.contract(address=contract_address, abi=abi)
+
+    token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
+
+    response = story_client.IPAsset.register(
+        token_contract=MockERC721,
+        token_id=token_id
+    )
+
+    response = story_client.Permission.setPermission(
+        ip_asset=response['ipId'],
+        signer=account.address,
+        to="0x2ac240293f12032E103458451dE8A8096c5A72E8",
+        permission=1,
+        func="0x00000000"
+    )
+
+    assert response is not None, "Response is None, indicating the contract interaction failed."
+    assert 'txHash' in response, "Response does not contain 'txHash'."
+    assert response['txHash'] is not None, "'txHash' is None."
+    assert isinstance(response['txHash'], str), "'txHash' is not a string."
+    assert len(response['txHash']) > 0, "'txHash' is empty."

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -106,3 +106,13 @@ def approve(erc20_contract_address, web3, account, spender_address, amount):
 
 def getBlockTimestamp(web3):
     return (web3.eth.get_block('latest'))['timestamp']
+
+def check_event_in_tx(web3, tx_hash: str, event_text: str) -> bool:
+    tx_receipt = web3.eth.get_transaction_receipt(tx_hash)
+    event_signature = web3.keccak(text=event_text).hex()
+
+    for log in tx_receipt['logs']:
+        if log['topics'][0].hex() == event_signature:
+            return True
+
+    return False

--- a/tests/unit/resources/test_permission.py
+++ b/tests/unit/resources/test_permission.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+from web3 import Web3
+from dotenv import load_dotenv
+
+# Ensure the src directory is in the Python path
+current_dir = os.path.dirname(__file__)
+src_path = os.path.abspath(os.path.join(current_dir, '..', '..', '..'))
+if src_path not in sys.path:
+    sys.path.append(src_path)
+
+from src.story_protocol_python_sdk.resources.Permission import Permission
+
+# Load environment variables from .env file
+load_dotenv()
+private_key = os.getenv('WALLET_PRIVATE_KEY')
+rpc_url = os.getenv('RPC_PROVIDER_URL')
+
+# Initialize Web3
+web3 = Web3(Web3.HTTPProvider(rpc_url))
+
+# Check if connected
+if not web3.is_connected():
+    raise Exception("Failed to connect to Web3 provider")
+
+# Set up the account with the private key
+account = web3.eth.account.from_key(private_key)
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+@pytest.fixture
+def permission():
+    chain_id = 11155111  # Sepolia chain ID
+    return Permission(web3, account, chain_id)
+
+
+def test_unregistered_ip_account(permission):
+    with patch.object(permission, '_is_registered', return_value=False):
+        with pytest.raises(ValueError, match="The IP account with id 0x0000000000000000000000000000000000000000 is not registered."):
+            permission.setPermission(ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, 1)
+
+def test_invalid_signer_address(permission):
+    with pytest.raises(ValueError, match="The address 0xInvalidAddress that can call 'to' on behalf of the 'ip_asset' is not a valid address."):
+        permission.setPermission(ZERO_ADDRESS, "0xInvalidAddress", ZERO_ADDRESS, "0x11111111111111111111111111111")
+
+def test_invalid_to_address(permission):
+    with pytest.raises(ValueError, match="The recipient of the transaction 0xInvalidAddress is not a valid address."):
+        permission.setPermission(ZERO_ADDRESS, ZERO_ADDRESS, "0xInvalidAddress", "0x11111111111111111111111111111")
+
+def test_successful_transaction(permission):
+    ip_asset = "0x587AE719cACC8cC34188D9648d67CF885bE10558"
+    signer = "0x8059F63663576bE3605B3CcD30aaEb858C345640"
+    to = "0x2ac240293f12032E103458451dE8A8096c5A72E8"
+    func = "0x00000000"
+    permission_level = 1
+    tx_hash = "0x0c0cce07beb64ccfbdd59da111f23084ab7c9e96a951f7381af49e792d014c04"
+    
+    with patch.object(permission, '_is_registered', return_value=True), \
+         patch('story_protocol_python_sdk.resources.IPAccount.IPAccount.execute', return_value={'txHash': tx_hash}):
+        response = permission.setPermission(ip_asset, signer, to, permission_level, func)
+        assert response['txHash'] == tx_hash
+
+def test_transaction_request_fails(permission):
+    ip_asset = "0x587AE719cACC8cC34188D9648d67CF885bE10558"
+    signer = "0x8059F63663576bE3605B3CcD30aaEb858C345640"
+    to = "0x2ac240293f12032E103458451dE8A8096c5A72E8"
+    func = "0x00000000"
+    permission_level = 1
+    
+    with patch.object(permission, '_is_registered', return_value=True), \
+         patch('story_protocol_python_sdk.resources.IPAccount.IPAccount.execute', side_effect=Exception("Transaction failed")):
+        with pytest.raises(Exception) as excinfo:
+            permission.setPermission(ip_asset, signer, to, permission_level, func)
+        assert str(excinfo.value) == "Transaction failed"

--- a/tests/unit/test_story_client.py
+++ b/tests/unit/test_story_client.py
@@ -14,6 +14,8 @@ from story_protocol_python_sdk.story_client import StoryClient
 from story_protocol_python_sdk.resources.IPAsset import IPAsset
 from story_protocol_python_sdk.resources.License import License
 from story_protocol_python_sdk.resources.Royalty import Royalty
+from story_protocol_python_sdk.resources.IPAccount import IPAccount
+from story_protocol_python_sdk.resources.Permission import Permission
 
 # Load environment variables from .env file
 load_dotenv()
@@ -70,3 +72,13 @@ def test_royalty_client_getter(story_client):
     royalty = story_client.Royalty
     assert royalty is not None
     assert isinstance(royalty, Royalty)
+
+def test_ip_account_client_getter(story_client):
+    ip_account = story_client.IPAccount
+    assert ip_account is not None
+    assert isinstance(ip_account, IPAccount)
+
+def test_permission_getter(story_client):
+    permission = story_client.Permission
+    assert permission is not None
+    assert isinstance(permission, Permission)


### PR DESCRIPTION
## Description
Added Permission client (and respective unit/integration) which includes
- setPermission()

## Test Plan 
Ensure all unit tests related to IPAsset, Royalty, License, IPAccount, Permission, and StoryClient clients pass without any issues.
Ensure integration tests for Permission pass without any issues.

## Related Issue
n/a

## Notes
-  Will need to add the other permissions fns (ex: batch, etc) to this SDK when the dev branch for the TS SDK gets merged with its main branch