### PR TITLE
[FEATURE] Added Mint/Register SPG Function & Respective Test Cases

### DIFF
--- a/src/story_protocol_python_sdk/abi/SPG/SPG.json
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG.json
@@ -1,0 +1,1366 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "accessController",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ipAssetRegistry",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "licensingModule",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "coreMetadataModule",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "pilTemplate",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "licenseToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "AccessManagedInvalidAuthority",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "delay",
+        "type": "uint32"
+      }
+    ],
+    "name": "AccessManagedRequiredDelay",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "AccessManagedUnauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedInnerCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SPG__CallerNotMinterRole",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SPG__EmptyLicenseTokens",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "SPG__ZeroAddressParam",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "AuthorityUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      }
+    ],
+    "name": "CollectionCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ACCESS_CONTROLLER",
+    "outputs": [
+      {
+        "internalType": "contract IAccessController",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CORE_METADATA_MODULE",
+    "outputs": [
+      {
+        "internalType": "contract ICoreMetadataModule",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "IP_ASSET_REGISTRY",
+    "outputs": [
+      {
+        "internalType": "contract IIPAssetRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LICENSE_TOKEN",
+    "outputs": [
+      {
+        "internalType": "contract ILicenseToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LICENSING_MODULE",
+    "outputs": [
+      {
+        "internalType": "contract ILicensingModule",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PIL_TEMPLATE",
+    "outputs": [
+      {
+        "internalType": "contract IPILicenseTemplate",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "authority",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "uint32",
+        "name": "maxSupply",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "mintFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "mintFeeToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "createCollection",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "accessManager",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isConsumingScheduledOp",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      }
+    ],
+    "name": "mintAndRegisterIp",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "transferable",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "royaltyPolicy",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "mintingFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialUse",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "commercializerChecker",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "commercializerCheckerData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint32",
+            "name": "commercialRevShare",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commercialRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAllowed",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesApproval",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesReciprocal",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "derivativeRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "currency",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "uri",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PILTerms",
+        "name": "terms",
+        "type": "tuple"
+      }
+    ],
+    "name": "mintAndRegisterIpAndAttachPILTerms",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "licenseTermsId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address[]",
+            "name": "parentIpIds",
+            "type": "address[]"
+          },
+          {
+            "internalType": "address",
+            "name": "licenseTemplate",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "licenseTermsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "royaltyContext",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.MakeDerivative",
+        "name": "derivData",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "mintAndRegisterIpAndMakeDerivative",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "licenseTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "royaltyContext",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "mintAndRegisterIpAndMakeDerivativeWithLicenseTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigMetadata",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerIp",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "transferable",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "royaltyPolicy",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "mintingFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialUse",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "commercializerChecker",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "commercializerCheckerData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint32",
+            "name": "commercialRevShare",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commercialRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAllowed",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesApproval",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesReciprocal",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "derivativeRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "currency",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "uri",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PILTerms",
+        "name": "terms",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigMetadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigAttach",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerIpAndAttachPILTerms",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "licenseTermsId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address[]",
+            "name": "parentIpIds",
+            "type": "address[]"
+          },
+          {
+            "internalType": "address",
+            "name": "licenseTemplate",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "licenseTermsIds",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "bytes",
+            "name": "royaltyContext",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.MakeDerivative",
+        "name": "derivData",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigMetadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigRegister",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerIpAndMakeDerivative",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nftContract",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "licenseTokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "royaltyContext",
+        "type": "bytes"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataURI",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "nftMetadataHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.IPMetadata",
+        "name": "metadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigMetadata",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "signer",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IStoryProtocolGateway.SignatureData",
+        "name": "sigRegister",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerIpAndMakeDerivativeWithLicenseTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "ipId",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "transferable",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "royaltyPolicy",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "mintingFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "expiration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialUse",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "commercialAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "commercializerChecker",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "commercializerCheckerData",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint32",
+            "name": "commercialRevShare",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commercialRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAllowed",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesAttribution",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesApproval",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "derivativesReciprocal",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "derivativeRevCelling",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "currency",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "uri",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct PILTerms",
+        "name": "terms",
+        "type": "tuple"
+      }
+    ],
+    "name": "registerPILTermsAndAttach",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "licenseTermsId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newAuthority",
+        "type": "address"
+      }
+    ],
+    "name": "setAuthority",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newNftContractBeacon",
+        "type": "address"
+      }
+    ],
+    "name": "setNftContractBeacon",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newNftContract",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeCollections",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
@@ -1,0 +1,32 @@
+
+import json
+import os
+from web3 import Web3
+
+class SPGClient:
+    def __init__(self, web3: Web3):
+        self.web3 = web3
+        # Assuming config.json is located at the root of the project
+        config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'config.json'))
+        with open(config_path, 'r') as config_file:
+            config = json.load(config_file)
+        contract_address = None
+        for contract in config['contracts']:
+            if contract['contract_name'] == 'SPG':
+                contract_address = contract['contract_address']
+                break
+        if not contract_address:
+            raise ValueError(f"Contract address for SPG not found in config.json")
+        abi_path = os.path.join(os.path.dirname(__file__), 'SPG.json')
+        with open(abi_path, 'r') as abi_file:
+            abi = json.load(abi_file)
+        self.contract = self.web3.eth.contract(address=contract_address, abi=abi)
+    
+    def mintAndRegisterIpAndAttachPILTerms(self, nftContract, recipient, metadata, terms):
+        
+        return self.contract.functions.mintAndRegisterIpAndAttachPILTerms(nftContract, recipient, metadata, terms).transact()
+        
+    def build_mintAndRegisterIpAndAttachPILTerms_transaction(self, nftContract, recipient, metadata, terms, tx_params):
+        return self.contract.functions.mintAndRegisterIpAndAttachPILTerms(nftContract, recipient, metadata, terms).build_transaction(tx_params)
+    
+    

--- a/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
@@ -22,6 +22,14 @@ class SPGClient:
             abi = json.load(abi_file)
         self.contract = self.web3.eth.contract(address=contract_address, abi=abi)
     
+    def createCollection(self, name, symbol, maxSupply, mintFee, mintFeeToken, owner):
+        
+        return self.contract.functions.createCollection(name, symbol, maxSupply, mintFee, mintFeeToken, owner).transact()
+        
+    def build_createCollection_transaction(self, name, symbol, maxSupply, mintFee, mintFeeToken, owner, tx_params):
+        return self.contract.functions.createCollection(name, symbol, maxSupply, mintFee, mintFeeToken, owner).build_transaction(tx_params)
+    
+    
     def mintAndRegisterIpAndAttachPILTerms(self, nftContract, recipient, metadata, terms):
         
         return self.contract.functions.mintAndRegisterIpAndAttachPILTerms(nftContract, recipient, metadata, terms).transact()

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -206,7 +206,7 @@ class IPAsset:
             license_term = get_license_term_by_type(pil_type, {
                 'mintingFee': minting_fee,
                 'currency': currency,
-                'royaltyPolicy': "0xAAbaf349C7a2A84564F9CC4Ac130B3f19A718E86", 
+                'royaltyPolicy': "0xAAbaf349C7a2A84564F9CC4Ac130B3f19A718E86", #default royalty policy
                 'commercialRevShare': commercial_rev_share,
             })
 

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -200,6 +200,9 @@ class IPAsset:
             if pil_type is None or pil_type not in PIL_TYPE.values():
                 raise ValueError("PIL type is required and must be one of the predefined PIL types.")
 
+            if not self.web3.is_address(nft_contract):
+                raise ValueError(f"The NFT contract address {nft_contract} is not valid.")
+
             license_term = get_license_term_by_type(pil_type, {
                 'mintingFee': minting_fee,
                 'currency': currency,

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -6,10 +6,13 @@ from story_protocol_python_sdk.abi.IPAssetRegistry.IPAssetRegistry_client import
 from story_protocol_python_sdk.abi.LicensingModule.LicensingModule_client import LicensingModuleClient
 from story_protocol_python_sdk.abi.LicenseToken.LicenseToken_client import LicenseTokenClient
 from story_protocol_python_sdk.abi.LicenseRegistry.LicenseRegistry_client import LicenseRegistryClient
+from story_protocol_python_sdk.abi.SPG.SPG_client import SPGClient
 
+from story_protocol_python_sdk.utils.license_terms import get_license_term_by_type, PIL_TYPE
 from story_protocol_python_sdk.utils.transaction_utils import build_and_send_transaction
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 class IPAsset:
     """
@@ -28,6 +31,7 @@ class IPAsset:
         self.licensing_module_client = LicensingModuleClient(web3)
         self.license_token_client = LicenseTokenClient(web3)
         self.license_registry_client = LicenseRegistryClient(web3)
+        self.spg_client = SPGClient(web3)
 
     def _get_ip_id(self, token_contract: str, token_id: int) -> str:
         """
@@ -174,3 +178,111 @@ class IPAsset:
 
         except Exception as e:
             raise e
+
+    def mintAndRegisterIpAssetWithPilTerms(self, nft_contract: str, pil_type: str, metadata: dict = None, recipient: str = None, minting_fee: int = None, commercial_rev_share: int = None, currency: str = None, tx_options: dict = None) -> dict:
+        """
+        Mint an NFT from a collection and register it as an IP.
+
+        :param nft_contract str: The address of the NFT collection.
+        :param pil_type str: The type of the PIL.
+        :param metadata dict: [Optional] The metadata for the IP.
+            :param metadataURI str: [Optional] The URI of the metadata for the IP.
+            :param metadataHash str: [Optional] The metadata hash for the IP.
+            :param nftMetadataHash str: [Optional] The metadata hash for the IP NFT.
+        :param recipient str: [Optional] The address of the recipient of the minted NFT.
+        :param minting_fee int: [Optional] The fee to be paid when minting a license.
+        :param commercial_rev_share int: [Optional] Percentage of revenue that must be shared with the licensor.
+        :param currency str: [Optional] The ERC20 token to be used to pay the minting fee. The token must be registered in Story Protocol.
+        :param tx_options dict: [Optional] The transaction options.
+        :return dict: A dictionary with the transaction hash.
+        """
+        try:
+            if pil_type is None or pil_type not in PIL_TYPE.values():
+                raise ValueError("PIL type is required and must be one of the predefined PIL types.")
+
+            license_term = get_license_term_by_type(pil_type, {
+                'mintingFee': minting_fee,
+                'currency': currency,
+                'royaltyPolicy': "0xAAbaf349C7a2A84564F9CC4Ac130B3f19A718E86", 
+                'commercialRevShare': commercial_rev_share,
+            })
+
+            req_object = {
+                'nftContract': nft_contract,
+                'recipient': recipient if recipient else self.account.address,
+                'terms': license_term,
+                'metadata': {
+                    'metadataURI': "",
+                    'metadataHash': ZERO_HASH,
+                    'nftMetadataHash': ZERO_HASH,
+                },
+            }
+
+            if metadata:
+                req_object['metadata'].update({
+                    'metadataURI': metadata.get('metadataURI', ""),
+                    'metadataHash': metadata.get('metadataHash', ZERO_HASH),
+                    'nftMetadataHash': metadata.get('nftMetadataHash', ZERO_HASH),
+                })
+
+            response = build_and_send_transaction(
+                self.web3,
+                self.account,
+                self.spg_client.build_mintAndRegisterIpAndAttachPILTerms_transaction,
+                req_object['nftContract'],
+                req_object['recipient'],
+                req_object['metadata'],
+                req_object['terms'],
+                tx_options=tx_options
+            )
+
+            ip_registered = self._parse_tx_ip_registered_event(response['txReceipt'])
+            license_terms_id = self._parse_tx_license_terms_attached_event(response['txReceipt'])
+
+            return {
+                'txHash': response['txHash'],
+                'ipId': ip_registered['ipId'],
+                'licenseTermsId': license_terms_id,
+                'tokenId': ip_registered['tokenId']
+            }
+
+        except Exception as e:
+            raise e
+        
+    def _parse_tx_ip_registered_event(self, tx_receipt: dict) -> int:
+        """
+        Parse the IPRegistered event from a transaction receipt.
+
+        :param tx_receipt dict: The transaction receipt.
+        :return int: The ID of the license terms.
+        """
+        event_signature = self.web3.keccak(text="IPRegistered(address,uint256,address,uint256,string,string,uint256)").hex()
+
+        for log in tx_receipt['logs']:
+            if log['topics'][0].hex() == event_signature:
+                ip_id = '0x' + log['data'].hex()[26:66]
+                token_id = int(log['topics'][3].hex(), 16)
+
+                return {
+                    'ipId': self.web3.to_checksum_address(ip_id),
+                    'tokenId': token_id
+                }
+            
+        return None
+    
+    def _parse_tx_license_terms_attached_event(self, tx_receipt: dict) -> int:
+        """
+        Parse the LicenseTermsAttached event from a transaction receipt.
+
+        :param tx_receipt dict: The transaction receipt.
+        :return int: The ID of the license terms.
+        """
+        event_signature = self.web3.keccak(text="LicenseTermsAttached(address,address,address,uint256)").hex()
+
+        for log in tx_receipt['logs']:
+            if log['topics'][0].hex() == event_signature:
+                data = log['data']
+
+                license_terms_id  = int.from_bytes(data[-32:], byteorder='big')
+                return license_terms_id 
+        return None

--- a/src/story_protocol_python_sdk/resources/NFTClient.py
+++ b/src/story_protocol_python_sdk/resources/NFTClient.py
@@ -1,0 +1,82 @@
+#src/story_protcol_python_sdk/resources/NFTClient.py
+
+from web3 import Web3
+
+from story_protocol_python_sdk.abi.SPG.SPG_client import SPGClient
+
+from story_protocol_python_sdk.utils.license_terms import get_license_term_by_type, PIL_TYPE
+from story_protocol_python_sdk.utils.transaction_utils import build_and_send_transaction
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+class NFTClient:
+    """
+    NFTClient handles the creation of SPG NFT collections.
+
+    :param web3 Web3: An instance of Web3.
+    :param account: The account to use for transactions.
+    :param chain_id int: The ID of the blockchain network.
+    """    
+    def __init__(self, web3: Web3, account, chain_id: int):
+        self.web3 = web3
+        self.account = account
+        self.chain_id = chain_id
+
+        self.spg_client = SPGClient(web3)
+
+
+    def createNFTCollection(self, name: str, symbol: str, max_supply: int, mint_fee: int, mint_fee_token: str, owner: str, tx_options: dict = None) -> dict:
+        """
+        Creates a new SPG NFT Collection.
+
+        :param name str: The name of the collection.
+        :param symbol str: The symbol of the collection.
+        :param max_supply int: The maximum supply of the collection.
+        :param mint_fee int: The cost to mint a token.
+        :param mint_fee_token str: The token to mint.
+        :param owner str: The owner of the collection.
+        :param tx_options dict: [Optional] The transaction options.
+        :return dict: A dictionary with the transaction hash and collection address.
+        """
+        try:
+            if mint_fee is not None and (mint_fee < 0 or not self.web3.is_address(mint_fee_token or "")):
+                raise ValueError("Invalid mint fee token address, mint fee is greater than 0.")
+
+            response = build_and_send_transaction(
+                self.web3,
+                self.account,
+                self.spg_client.build_createCollection_transaction,
+                name,
+                symbol,
+                max_supply if max_supply is not None else 2**32 - 1,
+                mint_fee if mint_fee is not None else 0,
+                mint_fee_token if mint_fee_token is not None else ZERO_ADDRESS,
+                owner if owner else self.account.address,
+                tx_options=tx_options
+            )
+
+            collection_address  = self._parse_tx_collection_created_event(response['txReceipt'])
+
+            return {
+                'txHash': response['txHash'],
+                'nftContract': collection_address
+            }
+
+        except Exception as e:
+            raise e
+        
+    def _parse_tx_collection_created_event(self, tx_receipt: dict) -> int:
+        """
+        Parse the CollectionCreated event from a transaction receipt.
+
+        :param tx_receipt dict: The transaction receipt.
+        :return int: The ID of the license terms.
+        """
+        event_signature = self.web3.keccak(text="CollectionCreated(address)").hex()
+
+        for log in tx_receipt['logs']:
+            if log['topics'][0].hex() == event_signature:
+                return self.web3.to_checksum_address('0x' + log['topics'][1].hex()[-40:])
+
+        return None

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -108,6 +108,13 @@
             "functions": [
                 "checkPermission"
             ]
+        },
+        {
+            "contract_name": "SPG",
+            "contract_address": "0x69415CE984A79a3Cfbe3F51024C63b6C107331e3",
+            "functions": [
+                "mintAndRegisterIpAndAttachPILTerms"
+            ]
         }
 
     ]

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -113,7 +113,8 @@
             "contract_name": "SPG",
             "contract_address": "0x69415CE984A79a3Cfbe3F51024C63b6C107331e3",
             "functions": [
-                "mintAndRegisterIpAndAttachPILTerms"
+                "mintAndRegisterIpAndAttachPILTerms",
+                "createCollection"
             ]
         }
 

--- a/src/story_protocol_python_sdk/story_client.py
+++ b/src/story_protocol_python_sdk/story_client.py
@@ -14,6 +14,7 @@ from story_protocol_python_sdk.resources.License import License
 from story_protocol_python_sdk.resources.Royalty import Royalty
 from story_protocol_python_sdk.resources.IPAccount import IPAccount
 from story_protocol_python_sdk.resources.Permission import Permission
+from story_protocol_python_sdk.resources.NFTClient import NFTClient
 
 class StoryClient:
     """
@@ -44,6 +45,7 @@ class StoryClient:
         self._royalty = None
         self._ip_account = None
         self._permission = None
+        self._nft_client = None
 
     @property
     def IPAsset(self) -> IPAsset:
@@ -99,3 +101,14 @@ class StoryClient:
         if self._permission is None:
             self._permission = Permission(self.web3, self.account, self.chain_id)
         return self._permission
+    
+    @property
+    def NFTClient(self) -> NFTClient:
+        """
+        Access the NFTClient resource.
+
+        :return NFTClient: An instance of NFTClient.
+        """
+        if self._nft_client is None:
+            self._nft_client = NFTClient(self.web3, self.account, self.chain_id)
+        return self._nft_client

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -12,7 +12,7 @@ src_path = os.path.abspath(os.path.join(current_dir, '..', '..'))
 if src_path not in sys.path:
     sys.path.append(src_path)
 
-from utils import get_token_id, get_story_client_in_sepolia, MockERC721
+from utils import get_token_id, get_story_client_in_sepolia, MockERC721, MockERC20
 
 load_dotenv()
 private_key = os.getenv('WALLET_PRIVATE_KEY')
@@ -96,8 +96,7 @@ def story_client():
 #     assert isinstance(response['txHash'], str)
 #     assert len(response['txHash']) > 0
 
-def test_mint_register(story_client):
-
+def test_mint_register_non_commercial(story_client):
     txData = story_client.NFTClient.createNFTCollection(
         name="test-collection",
         symbol="TEST",
@@ -121,13 +120,104 @@ def test_mint_register(story_client):
         metadata=metadata
     )
 
-    print(f"Transaction Hash: {response['txHash']}")
-    print(f"IP ID: {response['ipId']}")
-    print(f"Token ID: {response['tokenId']}")
-    print(f"License Terms ID: {response['licenseTermsId']}")
+    assert 'txHash' in response
+    assert isinstance(response['txHash'], str)
+    assert response['txHash'].startswith("0x")
+
+    assert 'ipId' in response
+    assert isinstance(response['ipId'], str)
+    assert response['ipId'].startswith("0x")
+
+    assert 'tokenId' in response
+    assert isinstance(response['tokenId'], int)
+
+    assert 'licenseTermsId' in response
+    assert isinstance(response['licenseTermsId'], int)
+
+def test_mint_register_commercial_use(story_client):
+    txData = story_client.NFTClient.createNFTCollection(
+        name="test-collection",
+        symbol="TEST",
+        max_supply=25,
+        mint_fee=0,
+        mint_fee_token=ZERO_ADDRESS,
+        owner=None
+    )
+
+    nft_contract = txData['nftContract']
+    pil_type = 'commercial_use'
+    metadata = {
+        'metadataURI': "test-uri",
+        'metadataHash': web3.to_hex(web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
+    }
+    minting_fee = 100
+    commercial_rev_share = 10
+    currency = MockERC20
+
+    response = story_client.IPAsset.mintAndRegisterIpAssetWithPilTerms(
+        nft_contract=nft_contract,
+        pil_type=pil_type,
+        metadata=metadata,
+        minting_fee=minting_fee,
+        commercial_rev_share=commercial_rev_share,
+        currency=currency
+    )
 
     assert 'txHash' in response
+    assert isinstance(response['txHash'], str)
     assert response['txHash'].startswith("0x")
+
     assert 'ipId' in response
+    assert isinstance(response['ipId'], str)
+    assert response['ipId'].startswith("0x")
+
     assert 'tokenId' in response
+    assert isinstance(response['tokenId'], int)
+
     assert 'licenseTermsId' in response
+    assert isinstance(response['licenseTermsId'], int)
+
+def test_mint_register_commercial_remix(story_client):
+    txData = story_client.NFTClient.createNFTCollection(
+        name="test-collection",
+        symbol="TEST",
+        max_supply=25,
+        mint_fee=0,
+        mint_fee_token=ZERO_ADDRESS,
+        owner=None
+    )
+
+    nft_contract = txData['nftContract']
+    pil_type = 'commercial_remix'
+    metadata = {
+        'metadataURI': "test-uri",
+        'metadataHash': web3.to_hex(web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
+    }
+    minting_fee = 100
+    commercial_rev_share = 10
+    currency = MockERC20
+
+    response = story_client.IPAsset.mintAndRegisterIpAssetWithPilTerms(
+        nft_contract=nft_contract,
+        pil_type=pil_type,
+        metadata=metadata,
+        minting_fee=minting_fee,
+        commercial_rev_share=commercial_rev_share,
+        currency=currency
+    )
+    
+    assert 'txHash' in response
+    assert isinstance(response['txHash'], str)
+    assert response['txHash'].startswith("0x")
+
+    assert 'ipId' in response
+    assert isinstance(response['ipId'], str)
+    assert response['ipId'].startswith("0x")
+
+    assert 'tokenId' in response
+    assert isinstance(response['tokenId'], int)
+
+    assert 'licenseTermsId' in response
+    assert isinstance(response['licenseTermsId'], int)

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -26,21 +26,23 @@ if not web3.is_connected():
 # Set up the account with the private key
 account = web3.eth.account.from_key(private_key)
 
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
 @pytest.fixture
 def story_client():
     return get_story_client_in_sepolia(web3, account)
 
-def test_register_ip_asset(story_client):
-    token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
+# def test_register_ip_asset(story_client):
+#     token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
 
-    response = story_client.IPAsset.register(
-        token_contract=MockERC721,
-        token_id=token_id
-    )
+#     response = story_client.IPAsset.register(
+#         token_contract=MockERC721,
+#         token_id=token_id
+#     )
 
-    assert response is not None
-    assert 'ipId' in response
-    assert response['ipId'] is not None
+#     assert response is not None
+#     assert 'ipId' in response
+#     assert response['ipId'] is not None
 
 # def test_registerDerivative(story_client): #can only run once since using preset variables
 #     parent_ip_id = "0x567603411Fb957759Ac2090659B73cC5f099456D"
@@ -93,3 +95,39 @@ def test_register_ip_asset(story_client):
 #     assert response['txHash'] is not None
 #     assert isinstance(response['txHash'], str)
 #     assert len(response['txHash']) > 0
+
+def test_mint_register(story_client):
+
+    txData = story_client.NFTClient.createNFTCollection(
+        name="test-collection",
+        symbol="TEST",
+        max_supply=25,
+        mint_fee=0,
+        mint_fee_token=ZERO_ADDRESS,
+        owner=None
+    )
+
+    nft_contract = txData['nftContract']
+    pil_type = 'non_commercial_remix'
+    metadata = {
+        'metadataURI': "test-uri",
+        'metadataHash': web3.to_hex(web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
+    }
+
+    response = story_client.IPAsset.mintAndRegisterIpAssetWithPilTerms(
+        nft_contract=nft_contract,
+        pil_type=pil_type,
+        metadata=metadata
+    )
+
+    print(f"Transaction Hash: {response['txHash']}")
+    print(f"IP ID: {response['ipId']}")
+    print(f"Token ID: {response['tokenId']}")
+    print(f"License Terms ID: {response['licenseTermsId']}")
+
+    assert 'txHash' in response
+    assert response['txHash'].startswith("0x")
+    assert 'ipId' in response
+    assert 'tokenId' in response
+    assert 'licenseTermsId' in response


### PR DESCRIPTION
## Description
- Added mintAndRegisterIpAssetWithPilTerms() to IPAsset Client
- Created NFT Client for creating an NFT collection

## Test Plan 
Ensure all unit tests related to IPAsset, Royalty, License, IPAccount, Permission, and StoryClient clients pass without any issues.
Ensure integration tests for IPAsset (specifically the mint/register fn) pass without any issues.

## Related Issue
n/a

## Notes
- Need to add unit tests for NFT client but not important since creating an NFT collection is more for testing
- May need to add additional/more comprehensive checks for parameters in mint/register fn