### PR TITLE
[FEATURE] Added Register/Attach SPG Function & Respective Test Cases 

### DIFF
--- a/src/story_protocol_python_sdk/abi/CoreMetadataModule/CoreMetadataModule.json
+++ b/src/story_protocol_python_sdk/abi/CoreMetadataModule/CoreMetadataModule.json
@@ -1,0 +1,484 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_owners",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_signaturesRequired",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "CloseStream",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address payable",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "hash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "result",
+        "type": "bytes"
+      }
+    ],
+    "name": "ExecuteTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "frequency",
+        "type": "uint256"
+      }
+    ],
+    "name": "OpenStream",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "added",
+        "type": "bool"
+      }
+    ],
+    "name": "Owner",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newSigner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newSignaturesRequired",
+        "type": "uint256"
+      }
+    ],
+    "name": "addSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "closeStream",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "signatures",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "executeTransaction",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "getTransactionHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nonce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "frequency",
+        "type": "uint256"
+      }
+    ],
+    "name": "openStream",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "recover",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "oldSigner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newSignaturesRequired",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "signaturesRequired",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "streamBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "streamWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "streams",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "frequency",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "last",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newSignaturesRequired",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateSignaturesRequired",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/story_protocol_python_sdk/abi/CoreMetadataModule/CoreMetadataModule_client.py
+++ b/src/story_protocol_python_sdk/abi/CoreMetadataModule/CoreMetadataModule_client.py
@@ -1,0 +1,24 @@
+
+import json
+import os
+from web3 import Web3
+
+class CoreMetadataModuleClient:
+    def __init__(self, web3: Web3):
+        self.web3 = web3
+        # Assuming config.json is located at the root of the project
+        config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'config.json'))
+        with open(config_path, 'r') as config_file:
+            config = json.load(config_file)
+        contract_address = None
+        for contract in config['contracts']:
+            if contract['contract_name'] == 'CoreMetadataModule':
+                contract_address = contract['contract_address']
+                break
+        if not contract_address:
+            raise ValueError(f"Contract address for CoreMetadataModule not found in config.json")
+        abi_path = os.path.join(os.path.dirname(__file__), 'CoreMetadataModule.json')
+        with open(abi_path, 'r') as abi_file:
+            abi = json.load(abi_file)
+        self.contract = self.web3.eth.contract(address=contract_address, abi=abi)
+    

--- a/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
@@ -38,3 +38,11 @@ class SPGClient:
         return self.contract.functions.mintAndRegisterIpAndAttachPILTerms(nftContract, recipient, metadata, terms).build_transaction(tx_params)
     
     
+    def registerIpAndAttachPILTerms(self, nftContract, tokenId, metadata, terms, sigMetadata, sigAttach):
+        
+        return self.contract.functions.registerIpAndAttachPILTerms(nftContract, tokenId, metadata, terms, sigMetadata, sigAttach).transact()
+        
+    def build_registerIpAndAttachPILTerms_transaction(self, nftContract, tokenId, metadata, terms, sigMetadata, sigAttach, tx_params):
+        return self.contract.functions.registerIpAndAttachPILTerms(nftContract, tokenId, metadata, terms, sigMetadata, sigAttach).build_transaction(tx_params)
+    
+    

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -259,7 +259,7 @@ class IPAsset:
         except Exception as e:
             raise e
         
-    def register_ip_and_attach_pil_terms(self, nft_contract: str, token_id: int, pil_type: str, metadata: dict = None, deadline: int = None, minting_fee: int = None, commercial_rev_share: int = None, currency: str = None, tx_options: dict = None) -> dict:
+    def registerIpAndAttachPilTerms(self, nft_contract: str, token_id: int, pil_type: str, metadata: dict = None, deadline: int = None, minting_fee: int = None, commercial_rev_share: int = None, currency: str = None, tx_options: dict = None) -> dict:
         """
         Register a given NFT as an IP and attach Programmable IP License Terms.
 

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -323,12 +323,12 @@ class IPAsset:
                     'nftMetadataHash': metadata.get('nftMetadataHash', ZERO_HASH),
                 })
 
-            signature = self._get_permission_signature_for_spg(ip_id, self.core_metadata_module_client.contract.address, calculated_deadline, "setAll(address,string,bytes32,bytes32)", 1)
-            req_object['sigMetadata'] = {
-                'signer': self.web3.to_checksum_address(self.account.address),
-                'deadline': calculated_deadline,
-                'signature': signature,
-            }
+                signature = self._get_permission_signature_for_spg(ip_id, self.core_metadata_module_client.contract.address, calculated_deadline, "setAll(address,string,bytes32,bytes32)", 1)
+                req_object['sigMetadata'] = {
+                    'signer': self.web3.to_checksum_address(self.account.address),
+                    'deadline': calculated_deadline,
+                    'signature': signature,
+                }
 
             response = build_and_send_transaction(
                 self.web3,

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -1,12 +1,17 @@
 #src/story_protcol_python_sdk/resources/IPAsset.py
 
 from web3 import Web3
+from eth_account import Account
+from eth_account.messages import encode_typed_data
+from datetime import datetime
 
 from story_protocol_python_sdk.abi.IPAssetRegistry.IPAssetRegistry_client import IPAssetRegistryClient
 from story_protocol_python_sdk.abi.LicensingModule.LicensingModule_client import LicensingModuleClient
 from story_protocol_python_sdk.abi.LicenseToken.LicenseToken_client import LicenseTokenClient
 from story_protocol_python_sdk.abi.LicenseRegistry.LicenseRegistry_client import LicenseRegistryClient
 from story_protocol_python_sdk.abi.SPG.SPG_client import SPGClient
+from story_protocol_python_sdk.abi.CoreMetadataModule.CoreMetadataModule_client import CoreMetadataModuleClient
+from story_protocol_python_sdk.abi.AccessController.AccessController_client import AccessControllerClient
 
 from story_protocol_python_sdk.utils.license_terms import get_license_term_by_type, PIL_TYPE
 from story_protocol_python_sdk.utils.transaction_utils import build_and_send_transaction
@@ -32,7 +37,9 @@ class IPAsset:
         self.license_token_client = LicenseTokenClient(web3)
         self.license_registry_client = LicenseRegistryClient(web3)
         self.spg_client = SPGClient(web3)
-
+        self.core_metadata_module_client = CoreMetadataModuleClient(web3)
+        self.access_controller_client = AccessControllerClient(web3)
+        
     def _get_ip_id(self, token_contract: str, token_id: int) -> str:
         """
         Get the IP ID for a given token.
@@ -252,6 +259,101 @@ class IPAsset:
         except Exception as e:
             raise e
         
+    def register_ip_and_attach_pil_terms(self, nft_contract: str, token_id: int, pil_type: str, metadata: dict = None, deadline: int = None, minting_fee: int = None, commercial_rev_share: int = None, currency: str = None, tx_options: dict = None) -> dict:
+        """
+        Register a given NFT as an IP and attach Programmable IP License Terms.
+
+        :param nft_contract str: The address of the NFT collection.
+        :param token_id int: The ID of the NFT.
+        :param pil_type str: The type of the PIL.
+        :param metadata dict: [Optional] The metadata for the IP.
+            :param metadataURI str: [Optional] The metadata URI for the IP.
+            :param metadataHash str: [Optional] The metadata hash for the IP.
+            :param nftMetadataHash str: [Optional] The metadata hash for the IP NFT.
+        :param deadline int: [Optional] The deadline for the signature in milliseconds.
+        :param minting_fee int: [Optional] The fee to be paid when minting a license.
+        :param commercial_rev_share int: [Optional] Percentage of revenue that must be shared with the licensor.
+        :param currency str: [Optional] The ERC20 token to be used to pay the minting fee. The token must be registered in Story Protocol.
+        :param tx_options dict: [Optional] The transaction options.
+        :return dict: A dictionary with the transaction hash, license terms ID, and IP ID.
+        """
+        try:
+            if pil_type is None or pil_type not in PIL_TYPE.values():
+                raise ValueError("PIL type is required and must be one of the predefined PIL types.")
+            
+            ip_id = self._get_ip_id(nft_contract, token_id)
+            if self._is_registered(ip_id):
+                raise ValueError(f"The NFT with id {token_id} is already registered as IP.")
+
+            license_term = get_license_term_by_type(pil_type, {
+                'mintingFee': minting_fee,
+                'currency': currency,
+                'royaltyPolicy': "0xAAbaf349C7a2A84564F9CC4Ac130B3f19A718E86", #default royalty policy
+                'commercialRevShare': commercial_rev_share,
+            })
+
+            calculated_deadline = self._get_deadline(deadline=deadline)
+            sig_attach_signature = self._get_permission_signature_for_spg(ip_id, self.licensing_module_client.contract.address, calculated_deadline, "attachLicenseTerms(address,address,uint256)", 2)
+
+            req_object = {
+                'nftContract': nft_contract,
+                'tokenId': token_id,
+                'terms': license_term,
+                'metadata': {
+                    'metadataURI': "",
+                    'metadataHash': ZERO_HASH,
+                    'nftMetadataHash': ZERO_HASH,
+                },
+                'sigMetadata': {
+                    'signer': ZERO_ADDRESS,
+                    'deadline': 0,
+                    'signature': ZERO_HASH,
+                },
+                'sigAttach': {
+                    'signer': self.web3.to_checksum_address(self.account.address),
+                    'deadline': calculated_deadline,
+                    'signature': sig_attach_signature,
+                },
+            }
+
+            if metadata:
+                req_object['metadata'].update({
+                    'metadataURI': metadata.get('metadataURI', ""),
+                    'metadataHash': metadata.get('metadataHash', ZERO_HASH),
+                    'nftMetadataHash': metadata.get('nftMetadataHash', ZERO_HASH),
+                })
+
+            signature = self._get_permission_signature_for_spg(ip_id, self.core_metadata_module_client.contract.address, calculated_deadline, "setAll(address,string,bytes32,bytes32)", 1)
+            req_object['sigMetadata'] = {
+                'signer': self.web3.to_checksum_address(self.account.address),
+                'deadline': calculated_deadline,
+                'signature': signature,
+            }
+
+            response = build_and_send_transaction(
+                self.web3,
+                self.account,
+                self.spg_client.build_registerIpAndAttachPILTerms_transaction,
+                req_object['nftContract'],
+                req_object['tokenId'],
+                req_object['metadata'],
+                req_object['terms'],
+                req_object['sigMetadata'],
+                req_object['sigAttach'],
+                tx_options=tx_options
+            )
+
+            license_terms_id = self._parse_tx_license_terms_attached_event(response['txReceipt'])
+
+            return {
+                'txHash': response['txHash'],
+                'licenseTermsId': license_terms_id,
+                'ipId': ip_id
+            }
+
+        except Exception as e:
+            raise e
+
     def _parse_tx_ip_registered_event(self, tx_receipt: dict) -> int:
         """
         Parse the IPRegistered event from a transaction receipt.
@@ -289,3 +391,75 @@ class IPAsset:
                 license_terms_id  = int.from_bytes(data[-32:], byteorder='big')
                 return license_terms_id 
         return None
+    
+    def _get_permission_signature_for_spg(self, ip_id: str, module_address: str, deadline: int, selector: str, nonce: int) -> str:
+        """
+        Generate a permission signature for SPG.
+
+        :param ip_id str: The IP ID.
+        :param module_address str: The module address.
+        :param deadline int: The deadline for the signature in milliseconds.
+        :param selector str: The function selector.
+        :param nonce int: The nonce value.
+        :return str: The generated signature.
+        """
+        try:
+            domain_data = {
+                "name": "Story Protocol IP Account",
+                "version": "1",
+                "chainId": self.chain_id,
+                "verifyingContract": ip_id,
+            }
+
+            message_types = {
+                "Execute": [
+                    {"name": "to", "type": "address"},
+                    {"name": "value", "type": "uint256"},
+                    {"name": "data", "type": "bytes"},
+                    {"name": "nonce", "type": "uint256"},
+                    {"name": "deadline", "type": "uint256"},
+                ],
+            }
+
+            data = self.access_controller_client.contract.encode_abi(
+                fn_name="setPermission", 
+                args=[
+                    ip_id, 
+                    self.spg_client.contract.address, 
+                    module_address, 
+                    Web3.keccak(text=selector).hex()[:10], 
+                    1
+                ]
+            )
+
+            message_data = {
+                "to": self.access_controller_client.contract.address,
+                "value": 0,
+                "data": data,
+                "nonce": nonce,
+                "deadline": deadline,
+            }
+
+            signable_message = encode_typed_data(domain_data, message_types, message_data)
+            signed_message = Account.sign_message(signable_message, self.account.key)
+
+            return signed_message.signature.hex()
+
+        except Exception as e:
+            raise e
+        
+    def _get_deadline(self, deadline: int = None) -> int:
+        """
+        Calculate the deadline for a transaction.
+
+        :param deadline int: [Optional] The deadline value in milliseconds.
+        :return int: The calculated deadline in milliseconds.
+        """
+        current_timestamp = int(datetime.now().timestamp() * 1000)
+        
+        if deadline is not None:
+            if not isinstance(deadline, int) or deadline < 0:
+                raise ValueError("Invalid deadline value.")
+            return current_timestamp + deadline
+        else:
+            return current_timestamp + 1000

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -117,6 +117,12 @@
                 "createCollection",
                 "registerIpAndAttachPILTerms"
             ]
+        },
+        {
+            "contract_name": "CoreMetadataModule",
+            "contract_address": "0xDa498A3f7c8a88cb72201138C366bE3778dB9575",
+            "functions": [
+            ]
         }
 
     ]

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -114,7 +114,8 @@
             "contract_address": "0x69415CE984A79a3Cfbe3F51024C63b6C107331e3",
             "functions": [
                 "mintAndRegisterIpAndAttachPILTerms",
-                "createCollection"
+                "createCollection",
+                "registerIpAndAttachPILTerms"
             ]
         }
 

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -221,3 +221,43 @@ def test_mint_register_commercial_remix(story_client):
 
     assert 'licenseTermsId' in response
     assert isinstance(response['licenseTermsId'], int)
+
+def test_register_attach(story_client):
+    txData = story_client.NFTClient.createNFTCollection(
+        name="test-collection",
+        symbol="TEST",
+        max_supply=25,
+        mint_fee=0,
+        mint_fee_token=ZERO_ADDRESS,
+        owner=None
+    )
+
+    nft_contract = txData['nftContract']
+
+    token_id = get_token_id(nft_contract, story_client.web3, story_client.account)
+
+    pil_type = 'non_commercial_remix'
+    metadata = {
+        'metadataURI': "test-uri",
+        'metadataHash': web3.to_hex(web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
+    }
+
+    response = story_client.IPAsset.register_ip_and_attach_pil_terms(
+        nft_contract=nft_contract,
+        token_id=token_id,
+        pil_type=pil_type,
+        metadata=metadata,
+        deadline=1000,
+    )
+
+    assert 'txHash' in response
+    assert isinstance(response['txHash'], str)
+    assert response['txHash'].startswith("0x")
+
+    assert 'ipId' in response
+    assert isinstance(response['ipId'], str)
+    assert response['ipId'].startswith("0x")
+
+    assert 'licenseTermsId' in response
+    assert isinstance(response['licenseTermsId'], int)

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -243,7 +243,7 @@ def test_register_attach(story_client):
         'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
     }
 
-    response = story_client.IPAsset.register_ip_and_attach_pil_terms(
+    response = story_client.IPAsset.registerIpAndAttachPilTerms(
         nft_contract=nft_contract,
         token_id=token_id,
         pil_type=pil_type,


### PR DESCRIPTION
## Description
- Added registerIpAndAttachPilTerms() to IPAsset Client
- Added additional clients when init ip asset client for accessing contract addresses without needing to "hardcode"

## Test Plan 
Ensure all unit tests related to IPAsset, Royalty, License, IPAccount, Permission, and StoryClient clients pass without any issues.
Ensure integration tests for IPAsset (specifically the register/attach fn) pass without any issues.

## Related Issue
n/a

## Notes
- May need to add additional/more comprehensive checks for parameters
- Will need to update lines that use royalty policy to use self.royaltypolicylapclient.contract.address (something like this) in future PR