### PR TITLE
[FEATURE] Added Register/Derivative SPG Function & Respective Test Cases

### DIFF
--- a/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
@@ -46,3 +46,11 @@ class SPGClient:
         return self.contract.functions.registerIpAndAttachPILTerms(nftContract, tokenId, metadata, terms, sigMetadata, sigAttach).build_transaction(tx_params)
     
     
+    def registerIpAndMakeDerivative(self, nftContract, tokenId, derivData, metadata, sigMetadata, sigRegister):
+        
+        return self.contract.functions.registerIpAndMakeDerivative(nftContract, tokenId, derivData, metadata, sigMetadata, sigRegister).transact()
+        
+    def build_registerIpAndMakeDerivative_transaction(self, nftContract, tokenId, derivData, metadata, sigMetadata, sigRegister, tx_params):
+        return self.contract.functions.registerIpAndMakeDerivative(nftContract, tokenId, derivData, metadata, sigMetadata, sigRegister).build_transaction(tx_params)
+    
+    

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -378,10 +378,6 @@ class IPAsset:
             ip_id = self._get_ip_id(nft_contract, token_id)
             if self._is_registered(ip_id):
                 raise ValueError(f"The NFT with id {token_id} is already registered as IP.")
-            
-            for parent_id in deriv_data['parentIpIds']:
-                if not self._is_registered(parent_id):
-                    raise ValueError(f"The parent IP with id {parent_id} is not registered.")
 
             if len(deriv_data['parentIpIds']) != len(deriv_data['licenseTermsIds']):
                 raise ValueError("Parent IP IDs and license terms IDs must match in quantity.")

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -115,7 +115,8 @@
             "functions": [
                 "mintAndRegisterIpAndAttachPILTerms",
                 "createCollection",
-                "registerIpAndAttachPILTerms"
+                "registerIpAndAttachPILTerms",
+                "registerIpAndMakeDerivative"
             ]
         },
         {


### PR DESCRIPTION
## Description
Added registerDerivativeIp() to IPAsset Client

## Test Plan 
Ensure all unit tests related to IPAsset, Royalty, License, IPAccount, Permission, and StoryClient clients pass without any issues.
Ensure integration tests for IPAsset (specifically the register/derivative fn) pass without any issues.

## Related Issue
n/a

## Notes
- Need to add check if parent ip ids are registered as ipas (may need to create a separate function for checking if nft is registered as ipas rather than using existing is_registered fn for unit tests for mocking)
- May need to add additional/more comprehensive checks for parameters (related to bullet above)