### PR TITLE
[UPDATE] Enabled Continuous Execution of Integration Test

### DIFF
--- a/src/story_protocol_python_sdk/resources/IPAccount.py
+++ b/src/story_protocol_python_sdk/resources/IPAccount.py
@@ -4,6 +4,7 @@ from web3 import Web3
 
 from story_protocol_python_sdk.abi.IPAccountImpl.IPAccountImpl_client import IPAccountImplClient
 from story_protocol_python_sdk.abi.IPAssetRegistry.IPAssetRegistry_client import IPAssetRegistryClient
+from story_protocol_python_sdk.abi.AccessController.AccessController_client import AccessControllerClient
 
 from story_protocol_python_sdk.utils.transaction_utils import build_and_send_transaction
 
@@ -21,6 +22,7 @@ class IPAccount:
         self.chain_id = chain_id
 
         self.ip_asset_registry_client = IPAssetRegistryClient(web3)
+        self.access_controller_client = AccessControllerClient(web3)
 
     def execute(self, to: str, value: int, account_address: str, data: str) -> dict:
         """

--- a/src/story_protocol_python_sdk/resources/Royalty.py
+++ b/src/story_protocol_python_sdk/resources/Royalty.py
@@ -61,21 +61,21 @@ class Royalty:
         except Exception as e:
             raise e
 
-    def _getRoyaltyVaultAddress(self, child_ip_id: str) -> str:
+    def _getRoyaltyVaultAddress(self, ip_id: str) -> str:
         """
-        Get the royalty vault address for a given child IP ID.
+        Get the royalty vault address for a given IP ID.
 
-        :param child_ip_id str: The derivative IP ID.
+        :param ip_id str: The IP ID.
         :return str: The respective royalty vault address.
         """
-        is_registered = self.ip_asset_registry_client.isRegistered(child_ip_id)
+        is_registered = self.ip_asset_registry_client.isRegistered(ip_id)
         if not is_registered:
-            raise ValueError(f"The child IP with id {child_ip_id} is not registered.")
+            raise ValueError(f"The IP with id {ip_id} is not registered.")
 
-        data = self.royalty_policy_lap_client.getRoyaltyData(child_ip_id)
+        data = self.royalty_policy_lap_client.getRoyaltyData(ip_id)
 
         if not data or not data[1] or data[1] == "0x":
-            raise ValueError(f"The royalty vault IP with id {child_ip_id} address is not set.")
+            raise ValueError(f"The royalty vault IP with id {ip_id} address is not set.")
         
         return data[1]
 
@@ -97,16 +97,16 @@ class Royalty:
 
         return None
     
-    def snapshot(self, child_ip_id: str, tx_options: dict = None) -> dict:
+    def snapshot(self, parent_ip_id: str, tx_options: dict = None) -> dict:
         """
         Snapshots the claimable revenue and royalty token amounts.
 
-        :param child_ip_id str: The derivative IP ID.
+        :param parent_ip_id str: The parent IP ID.
         :param tx_options dict: [Optional] The transaction options.
         :return dict: A dictionary with the transaction hash and the snapshot ID.
         """
         try:
-            proxy_address = self._getRoyaltyVaultAddress(child_ip_id)
+            proxy_address = self._getRoyaltyVaultAddress(parent_ip_id)
             ip_royalty_vault_client = IpRoyaltyVaultImplClient(self.web3, contract_address=proxy_address)
 
             response = build_and_send_transaction(
@@ -144,18 +144,18 @@ class Royalty:
 
         return None
 
-    def claimableRevenue(self, child_ip_id: str, account_address: str, snapshot_id: int, token: str) -> int:
+    def claimableRevenue(self, parent_ip_id: str, account_address: str, snapshot_id: int, token: str) -> int:
         """
         Calculates the amount of revenue token claimable by a token holder at certain snapshot.
 
-        :param child_ip_id str: The derivative IP ID.
+        :param parent_ip_id str: The parent IP ID.
         :param account_address str: The address of the token holder.
         :param snapshot_id int: The snapshot ID.
         :param token str: The revenue token to claim.
         :return int: The claimable revenue amount.
         """
         try:
-            proxy_address = self._getRoyaltyVaultAddress(child_ip_id)
+            proxy_address = self._getRoyaltyVaultAddress(parent_ip_id)
             ip_royalty_vault_client = IpRoyaltyVaultImplClient(self.web3, contract_address=proxy_address)
 
             claimable_revenue = ip_royalty_vault_client.claimableRevenue(
@@ -205,18 +205,18 @@ class Royalty:
         except Exception as e:
             raise e
     
-    def claimRevenue(self, snapshot_ids: list, child_ip_id: str, token: str, tx_options: dict = None) -> dict:
+    def claimRevenue(self, snapshot_ids: list, parent_ip_id: str, token: str, tx_options: dict = None) -> dict:
         """
         Allows token holders to claim by a list of snapshot IDs based on the token balance at certain snapshot.
 
         :param snapshot_ids list: The list of snapshot IDs.
-        :param child_ip_id str: The derivative IP ID.
+        :param parent_ip_id str: The parent IP ID.
         :param token str: The revenue token to claim.
         :param tx_options dict: [Optional] The transaction options.
         :return dict: A dictionary with the transaction hash and the number of claimable tokens.
         """
         try:
-            proxy_address = self._getRoyaltyVaultAddress(child_ip_id)
+            proxy_address = self._getRoyaltyVaultAddress(parent_ip_id)
             ip_royalty_vault_client = IpRoyaltyVaultImplClient(self.web3, contract_address=proxy_address)
 
             response = build_and_send_transaction(

--- a/tests/integration/test_integration_permission.py
+++ b/tests/integration/test_integration_permission.py
@@ -30,22 +30,6 @@ def story_client():
     return get_story_client_in_sepolia(web3, account)
 
 def test_setPermission(story_client):
-    config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'story_protocol_python_sdk', 'scripts', 'config.json'))
-    with open(config_path, 'r') as config_file:
-        config = json.load(config_file)
-    contract_address = None
-    for contract in config['contracts']:
-        if contract['contract_name'] == 'AccessController':
-            contract_address = contract['contract_address']
-            break
-    if not contract_address:
-        raise ValueError(f"Contract address for AccessController not found in config.json")
-    abi_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'story_protocol_python_sdk', 'abi', 'AccessController', 'AccessController.json'))
-    with open(abi_path, 'r') as abi_file:
-        abi = json.load(abi_file)
-
-    contract = web3.eth.contract(address=contract_address, abi=abi)
-
     token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
 
     response = story_client.IPAsset.register(

--- a/tests/unit/resources/test_royalty.py
+++ b/tests/unit/resources/test_royalty.py
@@ -47,7 +47,7 @@ def test_collectRoyaltyTokens_royalty_vault_ip_id_not_registered(royalty_client)
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', side_effect=[True, False], autospec=True):
         with pytest.raises(ValueError) as excinfo:
             royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        assert str(excinfo.value) == f"The child IP with id {child_ip_id} is not registered."
+        assert str(excinfo.value) == f"The IP with id {child_ip_id} is not registered."
 
 def test_collectRoyaltyTokens_royalty_vault_address_empty(royalty_client):
     parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
@@ -97,18 +97,18 @@ def test_collectRoyaltyTokens_success(royalty_client):
         
 def test_snapshot_royaltyVaultIpId_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
-        child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+        parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
         
-        with pytest.raises(ValueError, match=f"The child IP with id {child_ip_id} is not registered."):
-            royalty_client.snapshot(child_ip_id)
+        with pytest.raises(ValueError, match=f"The IP with id {parent_ip_id} is not registered."):
+            royalty_client.snapshot(parent_ip_id)
 
 def test_snapshot_royaltyVaultAddress_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
         with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
-            child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+            parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
 
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {child_ip_id} address is not set."):
-                royalty_client.snapshot(child_ip_id)
+            with pytest.raises(ValueError, match=f"The royalty vault IP with id {parent_ip_id} address is not set."):
+                royalty_client.snapshot(parent_ip_id)
 
 def test_snapshot_success(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
@@ -122,9 +122,9 @@ def test_snapshot_success(royalty_client):
                 }):
                     with patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr='0x471343c1ad3b358843b2079d8c5c1a0a5a86fe88382cdc67604b0209bbedf523')):
                         with patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
-                            child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+                            parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
 
-                            response = royalty_client.snapshot(child_ip_id)
+                            response = royalty_client.snapshot(parent_ip_id)
                             assert response is not None
                             assert 'txHash' in response
                             assert response['txHash'] == '471343c1ad3b358843b2079d8c5c1a0a5a86fe88382cdc67604b0209bbedf523'
@@ -133,55 +133,55 @@ def test_snapshot_success(royalty_client):
 
 def test_claimableRevenue_royaltyVaultIpId_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
-        child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+        parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
         account_address = account.address
         snapshot_id = 1
         token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
 
-        with pytest.raises(ValueError, match=f"The child IP with id {child_ip_id} is not registered."):
-            royalty_client.claimableRevenue(child_ip_id, account_address, snapshot_id, token)
+        with pytest.raises(ValueError, match=f"The IP with id {parent_ip_id} is not registered."):
+            royalty_client.claimableRevenue(parent_ip_id, account_address, snapshot_id, token)
 
 def test_claimableRevenue_royaltyVaultAddress_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
         with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
-            child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+            parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
             account_address = account.address
             snapshot_id = 1
             token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
 
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {child_ip_id} address is not set."):
-                royalty_client.claimableRevenue(child_ip_id, account_address, snapshot_id, token)
+            with pytest.raises(ValueError, match=f"The royalty vault IP with id {parent_ip_id} address is not set."):
+                royalty_client.claimableRevenue(parent_ip_id, account_address, snapshot_id, token)
 
 def test_claimableRevenue_success(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
         with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
             with patch('story_protocol_python_sdk.abi.IpRoyaltyVaultImpl.IpRoyaltyVaultImpl_client.IpRoyaltyVaultImplClient.claimableRevenue', return_value=0):
-                child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
+                parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
                 account_address = account.address
                 snapshot_id = 1
                 token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
 
-                response = royalty_client.claimableRevenue(child_ip_id, account_address, snapshot_id, token)
+                response = royalty_client.claimableRevenue(parent_ip_id, account_address, snapshot_id, token)
                 assert response == 0
 
 def test_claimRevenue_royaltyVaultIpId_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
-        child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
+        parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
         ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
         snapshot_ids = [1, 2]
 
-        with pytest.raises(ValueError, match=f"The child IP with id {child_ip_id} is not registered."):
-            royalty_client.claimRevenue(snapshot_ids, child_ip_id, ERC20)
+        with pytest.raises(ValueError, match=f"The IP with id {parent_ip_id} is not registered."):
+            royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
 
 def test_claimRevenue_royaltyVaultAddress_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
         with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"], [1]]):
-            child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
+            parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
             ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
             snapshot_ids = [1, 2]
 
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {child_ip_id} address is not set."):
-                royalty_client.claimRevenue(snapshot_ids, child_ip_id, ERC20)
+            with pytest.raises(ValueError, match=f"The royalty vault IP with id {parent_ip_id} address is not set."):
+                royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
 
 def test_claimRevenue_success(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
@@ -195,11 +195,11 @@ def test_claimRevenue_success(royalty_client):
                 }):
                     with patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr='0x7065317271b179a2b4d47ff23b9b12ea50cdf668b892c8912cd7df71797b6561')):
                         with patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
-                            child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
+                            parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
                             ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
                             snapshot_ids = [1, 2]
 
-                            response = royalty_client.claimRevenue(snapshot_ids, child_ip_id, ERC20)
+                            response = royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
                             assert response is not None
                             assert 'txHash' in response
                             assert response['txHash'] == '7065317271b179a2b4d47ff23b9b12ea50cdf668b892c8912cd7df71797b6561'


### PR DESCRIPTION
## Description
- Refactored the integration tests to remove dependencies on specific values, enabling them to be run continuously and repeatedly. This ensures that the entire test suite can be executed without manual modifications.
- Updated Royalty Client so that instead of using child_ip_id in certain functions (ex: snapshot), the variable should be called parent_ip_id to be more clear/accurate

## Test Plan 
Calling 'pytest' should ensure that BOTH integration and unit tests pass seamlessly. 

## Related Issue
n/a

## Notes
n/a