### PR TITLE
[UPDATE] Updated Register() fn to take in optional metadata & deadline

### DIFF
--- a/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
+++ b/src/story_protocol_python_sdk/abi/SPG/SPG_client.py
@@ -38,6 +38,14 @@ class SPGClient:
         return self.contract.functions.mintAndRegisterIpAndAttachPILTerms(nftContract, recipient, metadata, terms).build_transaction(tx_params)
     
     
+    def registerIp(self, nftContract, tokenId, metadata, sigMetadata):
+        
+        return self.contract.functions.registerIp(nftContract, tokenId, metadata, sigMetadata).transact()
+        
+    def build_registerIp_transaction(self, nftContract, tokenId, metadata, sigMetadata, tx_params):
+        return self.contract.functions.registerIp(nftContract, tokenId, metadata, sigMetadata).build_transaction(tx_params)
+    
+    
     def registerIpAndAttachPILTerms(self, nftContract, tokenId, metadata, terms, sigMetadata, sigAttach):
         
         return self.contract.functions.registerIpAndAttachPILTerms(nftContract, tokenId, metadata, terms, sigMetadata, sigAttach).transact()

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -325,12 +325,18 @@ class IPAsset:
                     'nftMetadataHash': metadata.get('nftMetadataHash', ZERO_HASH),
                 })
 
-                signature = self._get_permission_signature_for_spg(ip_id, self.core_metadata_module_client.contract.address, calculated_deadline, "setAll(address,string,bytes32,bytes32)", 1)
-                req_object['sigMetadata'] = {
-                    'signer': self.web3.to_checksum_address(self.account.address),
-                    'deadline': calculated_deadline,
-                    'signature': signature,
-                }
+            signature = self._get_permission_signature_for_spg(
+                ip_id, 
+                self.core_metadata_module_client.contract.address, 
+                calculated_deadline, 
+                "setAll(address,string,bytes32,bytes32)", 
+                1
+            )
+            req_object['sigMetadata'] = {
+                'signer': self.web3.to_checksum_address(self.account.address),
+                'deadline': calculated_deadline,
+                'signature': signature,
+            }
 
             response = build_and_send_transaction(
                 self.web3,
@@ -430,18 +436,18 @@ class IPAsset:
                     'nftMetadataHash': metadata.get('nftMetadataHash', ZERO_HASH),
                 })
 
-                signature = self._get_permission_signature_for_spg(
-                    ip_id,
-                    self.core_metadata_module_client.contract.address,
-                    calculated_deadline,
-                    "setAll(address,string,bytes32,bytes32)",
-                    1
-                )
-                req_object['sigMetadata'] = {
-                    'signer': self.web3.to_checksum_address(self.account.address),
-                    'deadline': calculated_deadline,
-                    'signature': signature,
-                }
+            signature = self._get_permission_signature_for_spg(
+                ip_id,
+                self.core_metadata_module_client.contract.address,
+                calculated_deadline,
+                "setAll(address,string,bytes32,bytes32)",
+                1
+            )
+            req_object['sigMetadata'] = {
+                'signer': self.web3.to_checksum_address(self.account.address),
+                'deadline': calculated_deadline,
+                'signature': signature,
+            }
 
             response = build_and_send_transaction(
                 self.web3,

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -636,3 +636,4 @@ class IPAsset:
             return current_timestamp + deadline
         else:
             return current_timestamp + 1000
+        

--- a/src/story_protocol_python_sdk/resources/IPAsset.py
+++ b/src/story_protocol_python_sdk/resources/IPAsset.py
@@ -41,29 +41,6 @@ class IPAsset:
         self.core_metadata_module_client = CoreMetadataModuleClient(web3)
         self.access_controller_client = AccessControllerClient(web3)
         self.pi_license_template_client = PILicenseTemplateClient(web3)
-        
-    def _get_ip_id(self, token_contract: str, token_id: int) -> str:
-        """
-        Get the IP ID for a given token.
-
-        :param token_contract str: The address of the NFT.
-        :param token_id int: The token identifier of the NFT.
-        :return str: The IP ID.
-        """
-        return self.ip_asset_registry_client.ipId(
-            self.chain_id, 
-            token_contract,
-            token_id
-        )
-
-    def _is_registered(self, ip_id: str) -> bool:
-        """
-        Check if an IP is registered.
-
-        :param ip_id str: The IP ID to check.
-        :return bool: True if registered, False otherwise.
-        """        
-        return self.ip_asset_registry_client.isRegistered(ip_id)
 
     def register(self, token_contract: str, token_id: int, tx_options: dict = None) -> dict:
         """
@@ -471,6 +448,29 @@ class IPAsset:
 
         except Exception as e:
             raise e
+
+    def _get_ip_id(self, token_contract: str, token_id: int) -> str:
+        """
+        Get the IP ID for a given token.
+
+        :param token_contract str: The address of the NFT.
+        :param token_id int: The token identifier of the NFT.
+        :return str: The IP ID.
+        """
+        return self.ip_asset_registry_client.ipId(
+            self.chain_id, 
+            token_contract,
+            token_id
+        )
+
+    def _is_registered(self, ip_id: str) -> bool:
+        """
+        Check if an IP is registered.
+
+        :param ip_id str: The IP ID to check.
+        :return bool: True if registered, False otherwise.
+        """        
+        return self.ip_asset_registry_client.isRegistered(ip_id)
 
     def _parse_tx_ip_registered_event(self, tx_receipt: dict) -> int:
         """

--- a/src/story_protocol_python_sdk/scripts/config.json
+++ b/src/story_protocol_python_sdk/scripts/config.json
@@ -116,7 +116,8 @@
                 "mintAndRegisterIpAndAttachPILTerms",
                 "createCollection",
                 "registerIpAndAttachPILTerms",
-                "registerIpAndMakeDerivative"
+                "registerIpAndMakeDerivative",
+                "registerIp"
             ]
         },
         {

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -50,6 +50,26 @@ def parent_ip_id(story_client):
 def test_register_ip_asset(story_client, parent_ip_id):
     assert parent_ip_id is not None
 
+def test_register_ip_asset_with_metadata(story_client):
+    token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
+    metadata = {
+        'metadataURI': "test-uri",
+        'metadataHash': web3.to_hex(web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': web3.to_hex(web3.keccak(text="test-nft-metadata-hash"))
+    }
+
+    response = story_client.IPAsset.register(
+        token_contract=MockERC721,
+        token_id=token_id,
+        metadata=metadata,
+        deadline=1000
+    )
+
+    assert response is not None
+    assert 'ipId' in response
+    assert response['ipId'] is not None
+    assert isinstance(response['ipId'], str)
+
 @pytest.fixture(scope="module")
 def attach_non_commercial_license(story_client, parent_ip_id):
     license_template = "0x260B6CB6284c89dbE660c0004233f7bB99B5edE7"

--- a/tests/unit/resources/test_ip_asset.py
+++ b/tests/unit/resources/test_ip_asset.py
@@ -31,8 +31,22 @@ ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 @pytest.fixture
 def ip_asset():
-    chain_id = 11155111  # Sepolia chain ID
+    chain_id = 11155111
     return IPAsset(web3, account, chain_id)
+
+def test_register_invalid_deadline_type(ip_asset):
+    with patch.object(ip_asset, '_get_ip_id', return_value="0xd142822Dc1674154EaF4DDF38bbF7EF8f0D8ECe4"), \
+         patch.object(ip_asset, '_is_registered', return_value=False):
+        with pytest.raises(ValueError, match="Invalid deadline value."):
+            ip_asset.register(
+                token_contract="0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+                token_id=3,
+                deadline="error",
+                metadata={
+                    'metadataURI': "1",
+                    'metadataHash': "0x0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            )
 
 def test_ip_asset_register_token_already_registered(ip_asset):
     token_contract = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
@@ -47,15 +61,14 @@ def test_ip_asset_register_token_already_registered(ip_asset):
         assert response['ipId'] == ip_id
         assert response['txHash'] is None
 
-def test_ip_asset_register_token_not_registered(ip_asset):
+def test_ip_asset_register_successful(ip_asset):
     token_contract = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
     token_id = "3"
     ip_id = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
     tx_hash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997"
 
-    # Mocking the expected behavior of the functions
-    with patch.object(ip_asset.ip_asset_registry_client, 'ipId', return_value=ip_id), \
-         patch.object(ip_asset.ip_asset_registry_client, 'isRegistered', return_value=False), \
+    with patch.object(ip_asset, '_get_ip_id', return_value=ip_id), \
+         patch.object(ip_asset, '_is_registered', return_value=False), \
          patch('story_protocol_python_sdk.abi.IPAssetRegistry.IPAssetRegistry_client.IPAssetRegistryClient.build_register_transaction', return_value={
              'data': '0x',
              'nonce': 0,
@@ -63,11 +76,46 @@ def test_ip_asset_register_token_not_registered(ip_asset):
              'gasPrice': Web3.to_wei('100', 'gwei')
          }), \
          patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr=tx_hash)), \
-         patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
+         patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}), \
+         patch.object(ip_asset, '_parse_tx_ip_registered_event', return_value={'ipId': ip_id}):
 
-        # Call the function being tested
         result = ip_asset.register(token_contract, token_id)
-        
+
+        assert result['txHash'] == tx_hash[2:]
+        assert result['ipId'] == ip_id
+
+def test_ip_asset_register_successful_with_metadata(ip_asset):
+    token_contract = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
+    token_id = "3"
+    ip_id = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
+    tx_hash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997"
+
+    metadata = {
+        'metadataURI': "",
+        'metadataHash': Web3.to_hex(Web3.keccak(text="test-metadata-hash")),
+        'nftMetadataHash': "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+    }
+
+    with patch.object(ip_asset, '_get_ip_id', return_value=ip_id), \
+         patch.object(ip_asset, '_is_registered', return_value=False), \
+         patch.object(ip_asset, '_get_permission_signature_for_spg', return_value="0xsignature"), \
+         patch('story_protocol_python_sdk.abi.SPG.SPG_client.SPGClient.build_registerIp_transaction', return_value={
+             'data': '0x',
+             'nonce': 0,
+             'gas': 2000000,
+             'gasPrice': Web3.to_wei('100', 'gwei')
+         }), \
+         patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr=tx_hash)), \
+         patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}), \
+         patch.object(ip_asset, '_parse_tx_ip_registered_event', return_value={'ipId': ip_id}):
+
+        result = ip_asset.register(
+            token_contract=token_contract,
+            token_id=token_id,
+            metadata=metadata,
+            deadline=1000
+        )
+
         assert result['txHash'] == tx_hash[2:]
         assert result['ipId'] == ip_id
 
@@ -132,7 +180,6 @@ def test_register_derivative_success(ip_asset):
     license_terms_ids = ["1"]
     tx_hash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997"
 
-    # Mocking the expected behavior of the functions
     with patch.object(ip_asset.ip_asset_registry_client, 'isRegistered', return_value=True), \
          patch.object(ip_asset.license_registry_client, 'hasIpAttachedLicenseTerms', return_value=True), \
          patch('story_protocol_python_sdk.abi.LicensingModule.LicensingModule_client.LicensingModuleClient.build_registerDerivative_transaction', return_value={
@@ -144,7 +191,6 @@ def test_register_derivative_success(ip_asset):
          patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr=tx_hash)), \
          patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
 
-        # Call the function being tested
         res = ip_asset.registerDerivative(child_ip_id, parent_ip_ids, license_terms_ids, "0x0000000000000000000000000000000000000000")
 
         assert res['txHash'] == tx_hash[2:]
@@ -167,7 +213,6 @@ def test_register_derivative_with_license_tokens_success(ip_asset):
     license_token_ids = ["1"]
     tx_hash = "0x129f7dd802200f096221dd89d5b086e4bd3ad6eafb378a0c75e3b04fc375f997"
 
-    # Mocking the expected behavior of the functions
     with patch.object(ip_asset.ip_asset_registry_client, 'isRegistered', return_value=True), \
          patch.object(ip_asset.license_token_client, 'ownerOf', return_value=ip_asset.account.address), \
          patch('story_protocol_python_sdk.abi.LicensingModule.LicensingModule_client.LicensingModuleClient.build_registerDerivativeWithLicenseTokens_transaction', return_value={
@@ -179,7 +224,6 @@ def test_register_derivative_with_license_tokens_success(ip_asset):
          patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr=tx_hash)), \
          patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
 
-        # Call the function being tested
         res = ip_asset.registerDerivativeWithLicenseTokens(child_ip_id, license_token_ids)
 
         assert res['txHash'] == tx_hash[2:]


### PR DESCRIPTION
## Description
- Updated register() fn in IPAsset client to take in optional metadata and deadline parameters
- Updated respective integration/unit tests
- Moved helper functions to bottom of client file

## Test Plan 
Ensure all unit tests for IPAsset pass without any issues.
Ensure integration tests for IPAsset (specifically the register fn) pass without any issues.

## Related Issue
n/a

## Notes
- Ankr RPC URL is broken (not sure if they changed something on their end) but is now incompatible with Python SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `registerIp` function to handle IP registration.
  - Introduced `build_registerIp_transaction` for transaction building.
  - Enhanced `register` method to support metadata and deadline parameters for IP assets.

- **Bug Fixes**
  - Improved transaction handling in IP registration.

- **Tests**
  - Added integration test for IP asset registration with metadata.
  - Introduced multiple unit tests for various registration scenarios, including invalid deadlines and successful registrations with metadata and license tokens.

- **Chores**
  - Updated `config.json` to include the `registerIp` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->