### PR TITLE
[UPDATE] Changed commercial_rev_share to be percentage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='story_protocol_python_sdk',
-    version='0.2.1',
+    version='0.3.1',
     packages=find_packages(where='src', exclude=["tests"]),
     package_dir={'': 'src'},
     install_requires=[

--- a/src/story_protocol_python_sdk/resources/License.py
+++ b/src/story_protocol_python_sdk/resources/License.py
@@ -126,7 +126,7 @@ class License:
             complete_license_terms = get_license_term_by_type(PIL_TYPE['COMMERCIAL_REMIX'], {
                 'mintingFee': minting_fee,
                 'currency': currency,
-                'commercialRevShare': commercial_rev_share,
+                'commercialRevShare': int((commercial_rev_share / 100) * 100000000),
                 'royaltyPolicy': royalty_policy,
             })
 


### PR DESCRIPTION
## Description
Previously, commercial_rev_share was an int representing the number of RTs. Now, commercial_rev_share is the percantage of RTs

## Test Plan 
Ensure all unit tests for License pass without any issues.
Ensure integration tests for License (specifically the register commercial remix fn) pass without any issues.

## Related Issue
n/a

## Notes
n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated SDK version to 0.3.1 for new functionalities and improvements.
	- Modified commercial revenue share calculations to ensure accurate percentage-based values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->