### PR TITLE
Removed `rc` for Pypi tagging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='story_protocol_python_sdk',
-    version='0.3.12rc1',
+    version='0.3.12',
     packages=find_packages(where='src', exclude=["tests"]),
     package_dir={'': 'src'},
     install_requires=[

--- a/src/story_protocol_python_sdk/__init__.py
+++ b/src/story_protocol_python_sdk/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.12rc1"
+__version__ = "0.3.12"
 
 from .story_client import StoryClient
 from .resources.IPAsset import IPAsset


### PR DESCRIPTION
## Description
This PR Removes `rc` for Pypi tagging so the latest version is always the stable one. 