### PR TITLE
Update test_integration_ip_account.py

### DIFF
--- a/tests/integration/test_integration_ip_account.py
+++ b/tests/integration/test_integration_ip_account.py
@@ -229,7 +229,6 @@ class TestSignatureOperations:
             ]
         )
 
-        # Calculate the expected state
         expected_state = Web3.keccak(
             encode(
                 ["bytes32", "bytes"],
@@ -237,7 +236,6 @@ class TestSignatureOperations:
             )
         )
 
-        # Prepare signature data
         domain_data = {
             "name": "Story Protocol IP Account",
             "version": "1",
@@ -345,24 +343,17 @@ class TestSetIpMetadata:
 
     def test_execute_with_sig_wrong_signer(self, story_client):
         """Test executeWithSig with a valid signature but wrong signer address."""
-        # Register a new IP
         token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
         register_response = story_client.IPAsset.register(
             nft_contract=MockERC721,
             token_id=token_id
         )
         ip_id = register_response['ipId']
-        
-        # Set a valid deadline
+
         deadline = getBlockTimestamp(web3) + 100
-        
-        # Get the current state/nonce
-        state = story_client.IPAccount.getIpAccountNonce(ip_id)
-        
-        # Prepare data for a simple operation
+        state = story_client.IPAccount.getIpAccountNonce(ip_id)        
         data = "0x"
         
-        # Prepare the expected state for signing
         execute_data = story_client.IPAccount.ip_account_client.contract.encode_abi(
             abi_element_identifier="execute",
             args=[
@@ -379,7 +370,6 @@ class TestSetIpMetadata:
             )
         )
         
-        # Prepare the signature data
         domain_data = {
             "name": "Story Protocol IP Account",
             "version": "1",
@@ -405,14 +395,10 @@ class TestSetIpMetadata:
             "deadline": deadline,
         }
         
-        # Sign the message
         signable_message = encode_typed_data(domain_data, message_types, message_data)
         signed_message = Account.sign_message(signable_message, private_key)
-        
-        # Use a wrong signer address
         wrong_signer = "0x1234567890123456789012345678901234567890"
         
-        # Execute with wrong signer
         with pytest.raises(Exception) as exc_info:
             story_client.IPAccount.executeWithSig(
                 ip_id=ip_id,
@@ -434,7 +420,6 @@ class TestSetIpMetadata:
     @pytest.mark.skip(reason="contract allows empty calls")
     def test_transfer_erc20_empty_tokens(self, story_client):
         """Test transferERC20 with empty tokens list."""
-        # Register a new IP
         token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
         register_response = story_client.IPAsset.register(
             nft_contract=MockERC721,
@@ -451,7 +436,6 @@ class TestSetIpMetadata:
     
     def test_transfer_erc20_invalid_token_params(self, story_client):
         """Test transferERC20 with invalid token parameters."""
-        # Register a new IP
         token_id = get_token_id(MockERC721, story_client.web3, story_client.account)
         register_response = story_client.IPAsset.register(
             nft_contract=MockERC721,
@@ -459,7 +443,6 @@ class TestSetIpMetadata:
         )
         ip_id = register_response['ipId']
         
-        # Test with missing address
         with pytest.raises(ValueError) as exc_info:
             story_client.IPAccount.transferERC20(
                 ip_id=ip_id,
@@ -472,10 +455,6 @@ class TestSetIpMetadata:
                 ]
             )
         assert "must include" in str(exc_info.value), "Error should mention missing parameter"
-        
-        # Test with missing target
-        # with pytest.raises(ValueError) as exc_info:
-        #     story_client.IPAccount
     
 
 class TestTransferERC20:

--- a/tests/integration/test_integration_ip_account.py
+++ b/tests/integration/test_integration_ip_account.py
@@ -106,14 +106,14 @@ class TestSignatureOperations:
             token_id=token_id
         )
 
-        ipId = response['ipId']
+        ip_id = response['ipId']
         deadline = getBlockTimestamp(web3) + 100
-        state = story_client.IPAccount.getIpAccountNonce(ipId)
+        state = story_client.IPAccount.getIpAccountNonce(ip_id)
 
         core_data = story_client.IPAccount.access_controller_client.contract.encode_abi(
             abi_element_identifier="setTransientPermission",
             args=[
-                ipId,
+                ip_id,
                 account.address,
                 "0x6E81a25C99C6e8430aeC7353325EB138aFE5DC16",
                 Web3.keccak(text="function setAll(address,string,bytes32,bytes32)")[:4],
@@ -141,7 +141,7 @@ class TestSignatureOperations:
             "name": "Story Protocol IP Account",
             "version": "1",
             "chainId": 1315,
-            "verifyingContract": ipId,
+            "verifyingContract": ip_id,
         }
 
         message_types = {
@@ -168,7 +168,7 @@ class TestSignatureOperations:
         response = story_client.IPAccount.executeWithSig(
             to=story_client.IPAccount.access_controller_client.contract.address,
             value=0,
-            ip_id=ipId,
+            ip_id=ip_id,
             data=core_data,
             signer=account.address,
             deadline=deadline,
@@ -469,7 +469,7 @@ class TestTransferERC20:
         )
         ip_id = response['ipId']
 
-        # 1. Query token balance of ipId and wallet before
+        # 1. Query token balance of ip_id and wallet before
         initial_erc20_balance_of_ip_id = story_client.Royalty.mock_erc20_client.balanceOf(
             account=ip_id
         )
@@ -527,7 +527,7 @@ class TestTransferERC20:
             ]
         )
         
-        # 5. Query token balance of ipId and wallet address after transfer
+        # 5. Query token balance of ip_id and wallet address after transfer
         final_erc20_balance_of_ip_id = story_client.Royalty.mock_erc20_client.balanceOf(
             account=ip_id
         )


### PR DESCRIPTION
## Description
The following PR increases coverage for `IPAccount` integration tests. I t adds the following test cases:

`test_execute_with_sig_wrong_signer`
`test_transfer_erc20_empty_tokens`
`test_transfer_erc20_invalid_token_params`
