### PR TITLE
[UPDATE] Updated Unit Tests for IPAccount, IPAsset, License & Royalty

### DIFF
--- a/tests/unit/resources/test_ip_account.py
+++ b/tests/unit/resources/test_ip_account.py
@@ -16,6 +16,7 @@ from src.story_protocol_python_sdk.resources.IPAccount import IPAccount
 
 # Constants
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000"
 VALID_IP_ID = "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c"
 TX_HASH = "0xe87b172eee35872179ced53ea4f3f314b12cd0f5d0034e7f0ae3c4efce9ba6f1"
 
@@ -27,7 +28,7 @@ class MockWeb3:
     @staticmethod
     def to_checksum_address(address):
         if not is_address(address):
-            raise ValueError(f"The recipient of the transaction {address} is not a valid address")
+            raise ValueError(f"Invalid address: {address}")
         return to_checksum_address(address)
     
     @staticmethod
@@ -61,8 +62,6 @@ def ip_account(mock_web3, mock_account):
     return IPAccount(mock_web3, mock_account, chain_id)
 
 @pytest.mark.unit
-@pytest.mark.unit
-@pytest.mark.unit
 class TestExecute:
     def test_invalid_recipient_address(self, ip_account):
         with pytest.raises(ValueError) as exc_info:
@@ -84,10 +83,10 @@ class TestExecute:
         mock_signed_txn = MagicMock()
         mock_signed_txn.raw_transaction = b'raw_transaction_bytes'
 
-        # Mock transaction hash with hex method that returns hash WITHOUT '0x' prefix
+        # Mock transaction hash with hex method that returns hash
         class MockTxHash:
             def hex(self):
-                return TX_HASH[2:]  # Remove '0x' prefix when returning the hash
+                return TX_HASH
 
         mock_tx_hash = MockTxHash()
 
@@ -100,7 +99,7 @@ class TestExecute:
             patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}):
 
             response = ip_account.execute(to_address, value, VALID_IP_ID, data)
-            assert response['txHash'] == TX_HASH[2:]
+            assert response['tx_hash'] == TX_HASH
 
     def test_wait_for_transaction(self, ip_account):
         to_address = "0xF9936a224b3Deb6f9A4645ccAfa66f7ECe83CF0A"
@@ -113,7 +112,7 @@ class TestExecute:
 
         class MockTxHash:
             def hex(self):
-                return TX_HASH[2:]  # Remove '0x' prefix when returning the hash
+                return TX_HASH
 
         mock_tx_hash = MockTxHash()
 
@@ -125,7 +124,7 @@ class TestExecute:
              patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}):
 
             response = ip_account.execute(to_address, value, VALID_IP_ID, data, tx_options=tx_options)
-            assert response['txHash'] == TX_HASH[2:]
+            assert response['tx_hash'] == TX_HASH
 
     def test_encoded_tx_data_only(self, ip_account):
         to_address = "0xF9936a224b3Deb6f9A4645ccAfa66f7ECe83CF0A"
@@ -157,7 +156,7 @@ class TestExecute:
 class TestExecuteWithSig:
     def test_invalid_recipient_address(self, ip_account):
         with pytest.raises(ValueError) as exc_info:
-            ip_account.executeWithSig(
+            ip_account.execute_with_sig(
                 VALID_IP_ID, 
                 "0xInvalidAddress", 
                 "0x11111111111111111111111111111",
@@ -180,7 +179,7 @@ class TestExecuteWithSig:
 
         class MockTxHash:
             def hex(self):
-                return TX_HASH[2:] 
+                return TX_HASH
 
         mock_tx_hash = MockTxHash()
         
@@ -191,8 +190,8 @@ class TestExecuteWithSig:
              patch.object(ip_account.web3.eth, 'send_raw_transaction', return_value=mock_tx_hash), \
              patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}):
 
-            response = ip_account.executeWithSig(VALID_IP_ID, to_address, data, signer, deadline, signature, value)
-            assert response['txHash'] == TX_HASH[2:]
+            response = ip_account.execute_with_sig(VALID_IP_ID, to_address, data, signer, deadline, signature, value)
+            assert response['tx_hash'] == TX_HASH
 
     def test_wait_for_transaction_with_sig(self, ip_account):
         to_address = "0xF9936a224b3Deb6f9A4645ccAfa66f7ECe83CF0A"
@@ -207,7 +206,7 @@ class TestExecuteWithSig:
         
         class MockTxHash:
             def hex(self):
-                return TX_HASH[2:]  # Remove '0x' prefix when returning the hash
+                return TX_HASH
 
         mock_tx_hash = MockTxHash()
         
@@ -218,16 +217,16 @@ class TestExecuteWithSig:
              patch.object(ip_account.web3.eth, 'send_raw_transaction', return_value=mock_tx_hash), \
              patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}):
 
-            response = ip_account.executeWithSig(
+            response = ip_account.execute_with_sig(
                 VALID_IP_ID, to_address, data, signer, deadline, signature,
                 tx_options=tx_options
             )
-            assert response['txHash'] == TX_HASH[2:]
+            assert response['tx_hash'] == TX_HASH
 
 class TestGetIpAccountNonce:
     def test_invalid_ip_id(self, ip_account):
         with pytest.raises(ValueError) as exc_info:
-            ip_account.getIpAccountNonce("0x123")  # invalid address
+            ip_account.get_ip_account_nonce("0x123")  # invalid address
         assert "Invalid IP id address" in str(exc_info.value)
 
     def test_successful_nonce_retrieval(self, ip_account):
@@ -237,25 +236,141 @@ class TestGetIpAccountNonce:
         with patch('story_protocol_python_sdk.abi.IPAccountImpl.IPAccountImpl_client.IPAccountImplClient.state', 
                 return_value=expected_nonce), \
             patch('web3.eth.Eth.contract', return_value=MagicMock()):
-            nonce = ip_account.getIpAccountNonce(ip_id)
+            nonce = ip_account.get_ip_account_nonce(ip_id)
             assert nonce == expected_nonce
 
 class TestGetToken:
     def test_invalid_ip_id(self, ip_account):
         with pytest.raises(ValueError) as exc_info:
-            ip_account.getToken("0x123")  # invalid address
+            ip_account.get_token("0x123")  # invalid address
         assert "Invalid IP id address" in str(exc_info.value)
 
     def test_successful_token_retrieval(self, ip_account):
         ip_id = Web3.to_checksum_address("0x73fcb515cee99e4991465ef586cfe2b072ebb512")
         expected_token = {
-            'chainId': 1513,
-            'tokenContract': ZERO_ADDRESS,
-            'tokenId': 1
+            'chain_id': 1513,
+            'token_contract': ZERO_ADDRESS,
+            'token_id': 1
         }
 
         with patch('story_protocol_python_sdk.abi.IPAccountImpl.IPAccountImpl_client.IPAccountImplClient.token',
                   return_value=[1513, ZERO_ADDRESS, 1]), \
              patch('web3.eth.Eth.contract', return_value=MagicMock()):
-            token = ip_account.getToken(ip_id)
+            token = ip_account.get_token(ip_id)
             assert token == expected_token
+
+class TestTransferERC20:
+    def test_unregistered_ip_id(self, ip_account):
+        with patch.object(ip_account, '_is_registered', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                ip_account.transfer_erc20(
+                    ip_id=VALID_IP_ID,
+                    tokens=[{
+                        'address': ZERO_ADDRESS,
+                        'target': ZERO_ADDRESS,
+                        'amount': 1000
+                    }]
+                )
+            assert f"IP id {VALID_IP_ID} is not registered" in str(exc_info.value)
+    
+    def test_invalid_token_params(self, ip_account):
+        with patch.object(ip_account, '_is_registered', return_value=True):
+            with pytest.raises(ValueError) as exc_info:
+                ip_account.transfer_erc20(
+                    ip_id=VALID_IP_ID,
+                    tokens=[{
+                        # Missing 'address'
+                        'target': ZERO_ADDRESS,
+                        'amount': 1000
+                    }]
+                )
+            assert "Each token transfer must include 'address', 'target', and 'amount'" in str(exc_info.value)
+    
+    def test_successful_transfer(self, ip_account):
+        tokens = [
+            {
+                'address': "0x1daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+                'target': "0xF60cBF0Ea1A61567F1dDaf79A6219D20d189155c",
+                'amount': 1000000
+            },
+            {
+                'address': "0x2daAE3197Bc469Cb97B917aa460a12dD95c6627c",
+                'target': "0xF60cBF0Ea1A61567F1dDaf79A6219D20d189155c",
+                'amount': 2000000
+            }
+        ]
+        
+        mock_signed_txn = MagicMock()
+        mock_signed_txn.raw_transaction = b'raw_transaction_bytes'
+        
+        class MockTxHash:
+            def hex(self):
+                return TX_HASH
+                
+        mock_tx_hash = MockTxHash()
+        
+        ip_account.account.sign_transaction = MagicMock(return_value=mock_signed_txn)
+        
+        with patch.object(ip_account, '_is_registered', return_value=True), \
+             patch.object(ip_account.web3.eth, 'get_transaction_count', return_value=0), \
+             patch.object(ip_account.web3.eth, 'send_raw_transaction', return_value=mock_tx_hash), \
+             patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}):
+            
+            response = ip_account.transfer_erc20(VALID_IP_ID, tokens)
+            assert response['tx_hash'] == TX_HASH
+
+class TestSetIPMetadata:
+    def test_unregistered_ip_id(self, ip_account):
+        with patch.object(ip_account, '_is_registered', return_value=False):
+            with pytest.raises(ValueError) as exc_info:
+                ip_account.set_ip_metadata(
+                    ip_id=VALID_IP_ID,
+                    metadata_uri="ipfs://example",
+                    metadata_hash=ZERO_HASH
+                )
+            assert f"IP id {VALID_IP_ID} is not registered" in str(exc_info.value)
+    
+    def test_successful_metadata_update(self, ip_account):
+        metadata_uri = "ipfs://example"
+        metadata_hash = ZERO_HASH
+        
+        mock_signed_txn = MagicMock()
+        mock_signed_txn.raw_transaction = b'raw_transaction_bytes'
+        
+        class MockTxHash:
+            def hex(self):
+                return TX_HASH
+                
+        mock_tx_hash = MockTxHash()
+        
+        # Create a mock contract with a valid address
+        mock_contract = MagicMock()
+        mock_contract.address = "0xF9936a224b3Deb6f9A4645ccAfa66f7ECe83CF0A"  # Use a valid address
+        
+        ip_account.account.sign_transaction = MagicMock(return_value=mock_signed_txn)
+        
+        with patch.object(ip_account, '_is_registered', return_value=True), \
+             patch.object(ip_account.web3.eth, 'get_transaction_count', return_value=0), \
+             patch.object(ip_account.web3.eth, 'send_raw_transaction', return_value=mock_tx_hash), \
+             patch.object(ip_account.web3.eth, 'wait_for_transaction_receipt', return_value={'status': 1}), \
+             patch.object(ip_account.web3.eth, 'contract', return_value=mock_contract), \
+             patch.object(ip_account.web3, 'is_address', return_value=True):
+            
+            response = ip_account.set_ip_metadata(VALID_IP_ID, metadata_uri, metadata_hash)
+            assert response['tx_hash'] == TX_HASH
+
+class TestOwner:
+    def test_invalid_ip_id(self, ip_account):
+        with pytest.raises(ValueError) as exc_info:
+            ip_account.owner("0x123")  # invalid address
+        assert "Invalid IP id address" in str(exc_info.value)
+    
+    def test_successful_owner_retrieval(self, ip_account):
+        ip_id = Web3.to_checksum_address("0x73fcb515cee99e4991465ef586cfe2b072ebb512")
+        expected_owner = "0xF60cBF0Ea1A61567F1dDaf79A6219D20d189155c"
+        
+        with patch('story_protocol_python_sdk.abi.IPAccountImpl.IPAccountImpl_client.IPAccountImplClient.owner', 
+                  return_value=expected_owner), \
+             patch('web3.eth.Eth.contract', return_value=MagicMock()):
+            owner = ip_account.owner(ip_id)
+            assert owner == expected_owner

--- a/tests/unit/resources/test_license.py
+++ b/tests/unit/resources/test_license.py
@@ -76,7 +76,7 @@ def license_client(mock_web3, mock_account):
 class TestPILTermsRegistration:
     """Tests for PIL (Programmable IP License) terms registration."""
 
-    def test_registerPILTerms_license_terms_id_registered(self, license_client):
+    def test_register_pil_terms_license_terms_id_registered(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=1), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyToken', return_value=True):
@@ -101,11 +101,11 @@ class TestPILTermsRegistration:
                 'uri': ''
             }
             
-            response = license_client.registerPILTerms(**license_terms)
-            assert response['licenseTermsId'] == 1
-            assert 'txHash' not in response
+            response = license_client.register_pil_terms(**license_terms)
+            assert response['license_terms_id'] == 1
+            assert 'tx_hash' not in response
 
-    def test_registerPILTerms_success(self, license_client, mock_signed_txn, mock_account):
+    def test_register_pil_terms_success(self, license_client, mock_signed_txn, mock_account):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyToken', return_value=True), \
@@ -115,7 +115,7 @@ class TestPILTermsRegistration:
              patch.object(license_client.web3.eth, 'send_raw_transaction', return_value=MockTxHash()), \
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()):
 
-            response = license_client.registerPILTerms(
+            response = license_client.register_pil_terms(
                 transferable=False,
                 royalty_policy=VALID_ADDRESS,
                 default_minting_fee=1513,
@@ -135,17 +135,17 @@ class TestPILTermsRegistration:
                 uri=''
             )
             
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
 
-    def test_registerPILTerms_commercial_rev_share_error_more_than_100(self, license_client):
+    def test_register_pil_terms_commercial_rev_share_error_more_than_100(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyToken', return_value=True):
 
             with pytest.raises(ValueError, match='CommercialRevShare should be between 0 and 100.'):
-                license_client.registerPILTerms(
+                license_client.register_pil_terms(
                     transferable=False,
                     royalty_policy=VALID_ADDRESS,
                     default_minting_fee=1,
@@ -165,13 +165,13 @@ class TestPILTermsRegistration:
                     uri=''
                 )
 
-    def test_registerPILTerms_commercial_rev_share_error_less_than_0(self, license_client):
+    def test_register_pil_terms_commercial_rev_share_error_less_than_0(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyToken', return_value=True):
 
             with pytest.raises(ValueError, match='CommercialRevShare should be between 0 and 100.'):
-                license_client.registerPILTerms(
+                license_client.register_pil_terms(
                     transferable=False,
                     royalty_policy=VALID_ADDRESS,
                     default_minting_fee=1,
@@ -193,13 +193,13 @@ class TestPILTermsRegistration:
 class TestNonComSocialRemixingPIL:
     """Tests for non-commercial social remixing PIL functionality."""
 
-    def test_registerNonComSocialRemixingPIL_license_terms_id_registered(self, license_client):
+    def test_register_non_com_social_remixing_pil_license_terms_id_registered(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=1):
-            response = license_client.registerNonComSocialRemixingPIL()
-            assert response['licenseTermsId'] == 1
-            assert 'txHash' not in response
+            response = license_client.register_non_com_social_remixing_pil()
+            assert response['license_terms_id'] == 1
+            assert 'tx_hash' not in response
 
-    def test_registerNonComSocialRemixingPIL_success(self, license_client, mock_signed_txn, mock_account):  
+    def test_register_non_com_social_remixing_pil_success(self, license_client, mock_signed_txn, mock_account):  
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_template_client, 'build_registerLicenseTerms_transaction',
                 return_value={'from': mock_account.address, 'nonce': 1, 'gas': 2000000, 'gasPrice': Web3.to_wei('100', 'gwei')}), \
@@ -209,35 +209,35 @@ class TestNonComSocialRemixingPIL:
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()), \
              patch.object(license_client, '_parse_tx_license_terms_registered_event', return_value=1): 
 
-            response = license_client.registerNonComSocialRemixingPIL()
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
-            assert 'licenseTermsId' in response
-            assert response['licenseTermsId'] == 1
+            response = license_client.register_non_com_social_remixing_pil()
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
+            assert 'license_terms_id' in response
+            assert response['license_terms_id'] == 1
 
-    def test_registerNonComSocialRemixingPIL_error(self, license_client):
+    def test_register_non_com_social_remixing_pil_error(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_template_client, 'build_registerLicenseTerms_transaction', 
                 side_effect=Exception("request fail.")):
 
             with pytest.raises(Exception, match="request fail."):
-                license_client.registerNonComSocialRemixingPIL()
+                license_client.register_non_com_social_remixing_pil()
 
 class TestCommercialUsePIL:
     """Tests for commercial use PIL functionality."""
     
-    def test_registerCommercialUsePIL_license_terms_id_registered(self, license_client):
+    def test_register_commercial_use_pil_license_terms_id_registered(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=1):
-            response = license_client.registerCommercialUsePIL(
+            response = license_client.register_commercial_use_pil(
                 default_minting_fee=1,
                 currency=ZERO_ADDRESS
             )
-            assert response['licenseTermsId'] == 1
-            assert 'txHash' not in response
+            assert response['license_terms_id'] == 1
+            assert 'tx_hash' not in response
 
-    def test_registerCommercialUsePIL_success(self, license_client, mock_signed_txn, mock_account):  
+    def test_register_commercial_use_pil_success(self, license_client, mock_signed_txn, mock_account):  
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_template_client, 'build_registerLicenseTerms_transaction', 
@@ -248,23 +248,23 @@ class TestCommercialUsePIL:
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()), \
              patch.object(license_client, '_parse_tx_license_terms_registered_event', return_value=1):
 
-            response = license_client.registerCommercialUsePIL(
+            response = license_client.register_commercial_use_pil(
                 default_minting_fee=1,
                 currency=ZERO_ADDRESS
             )
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
-            assert 'licenseTermsId' in response
-            assert response['licenseTermsId'] == 1
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
+            assert 'license_terms_id' in response
+            assert response['license_terms_id'] == 1
 
-    def test_registerCommercialUsePIL_error(self, license_client):
+    def test_register_commercial_use_pil_error(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_template_client, 'build_registerLicenseTerms_transaction', 
                 side_effect=Exception("request fail.")):
             with pytest.raises(Exception, match="request fail."):
-                license_client.registerCommercialUsePIL(
+                license_client.register_commercial_use_pil(
                     default_minting_fee=1,
                     currency=ZERO_ADDRESS
                 )
@@ -272,19 +272,19 @@ class TestCommercialUsePIL:
 class TestCommercialRemixPIL:
     """Tests for commercial remix PIL functionality."""
 
-    def test_registerCommercialRemixPIL_license_terms_id_registered(self, license_client):
+    def test_register_commercial_remix_pil_license_terms_id_registered(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=1), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True):
-            response = license_client.registerCommercialRemixPIL(
+            response = license_client.register_commercial_remix_pil(
                 default_minting_fee=1,
                 commercial_rev_share=100,
                 currency=ZERO_ADDRESS,
                 royalty_policy=ZERO_ADDRESS
             )
-            assert response['licenseTermsId'] == 1
-            assert 'txHash' not in response
+            assert response['license_terms_id'] == 1
+            assert 'tx_hash' not in response
 
-    def test_registerCommercialRemixPIL_success(self, license_client, mock_signed_txn, mock_account):
+    def test_register_commercial_remix_pil_success(self, license_client, mock_signed_txn, mock_account):
         with patch.object(license_client.license_template_client, 'getLicenseTermsId', return_value=0), \
              patch.object(license_client.license_terms_util.royalty_module_client, 'isWhitelistedRoyaltyPolicy', return_value=True), \
              patch.object(license_client.license_template_client, 'build_registerLicenseTerms_transaction', 
@@ -295,52 +295,52 @@ class TestCommercialRemixPIL:
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()), \
              patch.object(license_client, '_parse_tx_license_terms_registered_event', return_value=1): 
 
-            response = license_client.registerCommercialRemixPIL(
+            response = license_client.register_commercial_remix_pil(
                 default_minting_fee=1,
                 commercial_rev_share=100,
                 currency=ZERO_ADDRESS,
                 royalty_policy=ZERO_ADDRESS
             )
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
-            assert response['licenseTermsId'] == 1
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
+            assert response['license_terms_id'] == 1
 
 class TestLicenseAttachment:
     """Tests for license attachment functionality."""
 
-    def test_attachLicenseTerms_ip_not_registered(self, license_client):
+    def test_attach_license_terms_ip_not_registered(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=False):
             with pytest.raises(ValueError, match=f'The IP with id {ZERO_ADDRESS} is not registered.'):
-                license_client.attachLicenseTerms(
+                license_client.attach_license_terms(
                     ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1
                 )
 
-    def test_attachLicenseTerms_license_terms_not_exist(self, license_client):
+    def test_attach_license_terms_license_terms_not_exist(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_registry_client, 'exists', return_value=False):
             with pytest.raises(ValueError, match='License terms id 1 do not exist.'):
-                license_client.attachLicenseTerms(
+                license_client.attach_license_terms(
                     ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1
                 )
 
-    def test_attachLicenseTerms_already_attached(self, license_client):
+    def test_attach_license_terms_already_attached(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_registry_client, 'exists', return_value=True), \
              patch.object(license_client.license_registry_client, 'hasIpAttachedLicenseTerms', return_value=True):
             with pytest.raises(ValueError, 
                 match=f'License terms id 1 is already attached to the IP with id {ZERO_ADDRESS}.'):
-                license_client.attachLicenseTerms(
+                license_client.attach_license_terms(
                     ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1
                 )
 
-    def test_attachLicenseTerms_success(self, license_client, mock_signed_txn, mock_account):
+    def test_attach_license_terms_success(self, license_client, mock_signed_txn, mock_account):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_registry_client, 'exists', return_value=True), \
              patch.object(license_client.license_registry_client, 'hasIpAttachedLicenseTerms', return_value=False), \
@@ -352,23 +352,23 @@ class TestLicenseAttachment:
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()), \
              patch.object(license_client, '_parse_tx_license_terms_registered_event', return_value=1): 
 
-            response = license_client.attachLicenseTerms(
+            response = license_client.attach_license_terms(
                 ip_id=ZERO_ADDRESS,
                 license_template=ZERO_ADDRESS,
                 license_terms_id=1
             )
 
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
 
 class TestLicenseTokens:
     """Tests for license token minting functionality."""
 
-    def test_mintLicenseTokens_licensor_ip_not_registered(self, license_client):
+    def test_mint_license_tokens_licensor_ip_not_registered(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=False):
             with pytest.raises(ValueError, match=f"The licensor IP with id {ZERO_ADDRESS} is not registered."):
-                license_client.mintLicenseTokens(
+                license_client.mint_license_tokens(
                     licensor_ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1,
@@ -376,11 +376,11 @@ class TestLicenseTokens:
                     receiver=ZERO_ADDRESS
                 )
 
-    def test_mintLicenseTokens_license_terms_not_exist(self, license_client):
+    def test_mint_license_tokens_license_terms_not_exist(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_template_client, 'exists', return_value=False):
             with pytest.raises(ValueError, match='License terms id 1 do not exist.'):
-                license_client.mintLicenseTokens(
+                license_client.mint_license_tokens(
                     licensor_ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1,
@@ -388,13 +388,13 @@ class TestLicenseTokens:
                     receiver=ZERO_ADDRESS
                 )
 
-    def test_mintLicenseTokens_not_attached(self, license_client):
+    def test_mint_license_tokens_not_attached(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_template_client, 'exists', return_value=True), \
              patch.object(license_client.license_registry_client, 'hasIpAttachedLicenseTerms', return_value=False):
             with pytest.raises(ValueError, 
                 match=f'License terms id 1 is not attached to the IP with id {ZERO_ADDRESS}.'):
-                license_client.mintLicenseTokens(
+                license_client.mint_license_tokens(
                     licensor_ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1,
@@ -402,10 +402,10 @@ class TestLicenseTokens:
                     receiver=ZERO_ADDRESS
                 )
 
-    def test_mintLicenseTokens_invalid_template(self, license_client):
+    def test_mint_license_tokens_invalid_template(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True):
             with pytest.raises(ValueError, match='Address "invalid address" is invalid'):
-                license_client.mintLicenseTokens(
+                license_client.mint_license_tokens(
                     licensor_ip_id=ZERO_ADDRESS,
                     license_template="invalid address",
                     license_terms_id=1,
@@ -413,10 +413,10 @@ class TestLicenseTokens:
                     receiver=ZERO_ADDRESS
                 )
 
-    def test_mintLicenseTokens_invalid_receiver(self, license_client):
+    def test_mint_license_tokens_invalid_receiver(self, license_client):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True):
             with pytest.raises(ValueError, match='Address "invalid address" is invalid'):
-                license_client.mintLicenseTokens(
+                license_client.mint_license_tokens(
                     licensor_ip_id=ZERO_ADDRESS,
                     license_template=ZERO_ADDRESS,
                     license_terms_id=1,
@@ -424,7 +424,7 @@ class TestLicenseTokens:
                     receiver="invalid address"
                 )
 
-    def test_mintLicenseTokens_success(self, license_client, mock_signed_txn, mock_account):
+    def test_mint_license_tokens_success(self, license_client, mock_signed_txn, mock_account):
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.license_template_client, 'exists', return_value=True), \
              patch.object(license_client.license_registry_client, 'hasIpAttachedLicenseTerms', return_value=True), \
@@ -435,7 +435,7 @@ class TestLicenseTokens:
              patch.object(license_client.web3.eth, 'wait_for_transaction_receipt', return_value=MagicMock()), \
              patch.object(license_client, '_parse_tx_license_terms_registered_event', return_value=1): 
 
-            response = license_client.mintLicenseTokens(
+            response = license_client.mint_license_tokens(
                 licensor_ip_id=ZERO_ADDRESS,
                 license_template=ZERO_ADDRESS,
                 license_terms_id=1,
@@ -443,14 +443,14 @@ class TestLicenseTokens:
                 receiver=ZERO_ADDRESS
             )
 
-            assert 'txHash' in response
-            assert response['txHash'] == TX_HASH[2:]
-            assert isinstance(response['txHash'], str)
+            assert 'tx_hash' in response
+            assert response['tx_hash'] == TX_HASH[2:]
+            assert isinstance(response['tx_hash'], str)
 
 class TestLicenseTerms:
     """Tests for retrieving license terms."""
 
-    def test_getLicenseTerms_success(self, license_client):
+    def test_get_license_terms_success(self, license_client):
         mock_response = {
             'terms': {
                 'transferable': True,
@@ -473,31 +473,31 @@ class TestLicenseTerms:
             }
         }
         with patch.object(license_client.license_template_client, 'getLicenseTerms', return_value=mock_response):
-            response = license_client.getLicenseTerms(1)
+            response = license_client.get_license_terms(1)
             assert response == mock_response
 
-    def test_getLicenseTerms_not_exist(self, license_client):
+    def test_get_license_terms_not_exist(self, license_client):
         with patch.object(license_client.license_template_client, 'getLicenseTerms', 
                          side_effect=Exception("Given licenseTermsId is not exist.")):
             with pytest.raises(ValueError, match="Failed to get license terms: Given licenseTermsId is not exist."):
-                license_client.getLicenseTerms(1)
+                license_client.get_license_terms(1)
 
 class TestLicensingConfig:
     """Tests for license configuration functionality."""
 
-    def test_setLicensingConfig_missing_params(self, license_client):
+    def test_set_licensing_config_missing_params(self, license_client):
         incomplete_config = {
             'isSet': True,
             'mintingFee': 0,
         }
         with pytest.raises(ValueError, match="Missing required licensing_config parameters:"):
-            license_client.setLicensingConfig(
+            license_client.set_licensing_config(
                 ip_id=ZERO_ADDRESS,
                 license_terms_id=1,
                 licensing_config=incomplete_config
             )
 
-    def test_setLicensingConfig_negative_minting_fee(self, license_client):
+    def test_set_licensing_config_negative_minting_fee(self, license_client):
         config = {
             'isSet': True,
             'mintingFee': -1,
@@ -509,13 +509,13 @@ class TestLicensingConfig:
             'expectGroupRewardPool': ZERO_ADDRESS
         }
         with pytest.raises(ValueError, match="Failed to set licensing config: The minting fee must be greater than 0."):
-            license_client.setLicensingConfig(
+            license_client.set_licensing_config(
                 ip_id=ZERO_ADDRESS,
                 license_terms_id=1,
                 licensing_config=config
             )
 
-    def test_setLicensingConfig_unregistered_licensing_hook(self, license_client):
+    def test_set_licensing_config_unregistered_licensing_hook(self, license_client):
         custom_address = "0x1234567890123456789012345678901234567890"
         config = {
             'isSet': True,
@@ -530,13 +530,13 @@ class TestLicensingConfig:
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
              patch.object(license_client.module_registry_client, 'isRegistered', return_value=False):
             with pytest.raises(ValueError, match="Failed to set licensing config: The licensing hook is not registered."):
-                license_client.setLicensingConfig(
+                license_client.set_licensing_config(
                     ip_id=ZERO_ADDRESS,
                     license_terms_id=1,
                     licensing_config=config
                 )
 
-    def test_setLicensingConfig_template_terms_mismatch(self, license_client):
+    def test_set_licensing_config_template_terms_mismatch(self, license_client):
         config = {
             'isSet': True,
             'mintingFee': 1,
@@ -549,14 +549,14 @@ class TestLicensingConfig:
         }
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True):
             with pytest.raises(ValueError, match="Failed to set licensing config: The license template is zero address but license terms id is not zero."):
-                license_client.setLicensingConfig(
+                license_client.set_licensing_config(
                     ip_id=ZERO_ADDRESS,
                     license_terms_id=1,
                     license_template=ZERO_ADDRESS,
                     licensing_config=config
                 )
 
-    def test_setLicensingConfig_zero_address_with_rev_share(self, license_client):
+    def test_set_licensing_config_zero_address_with_rev_share(self, license_client):
         config = {
             'isSet': True,
             'mintingFee': 1,
@@ -569,7 +569,7 @@ class TestLicensingConfig:
         }
         with patch.object(license_client.ip_asset_registry_client, 'isRegistered', return_value=True):
             with pytest.raises(ValueError, match="Failed to set licensing config: The license template cannot be zero address if commercial revenue share is not zero."):
-                license_client.setLicensingConfig(
+                license_client.set_licensing_config(
                     ip_id=ZERO_ADDRESS,
                     license_terms_id=0,
                     license_template=ZERO_ADDRESS,

--- a/tests/unit/resources/test_royalty.py
+++ b/tests/unit/resources/test_royalty.py
@@ -28,185 +28,30 @@ account = web3.eth.account.from_key(private_key)
 
 @pytest.fixture
 def royalty_client():
-    chain_id = 11155111  # Sepolia chain ID
+    chain_id = 1315
     return Royalty(web3, account, chain_id)
 
-def test_collectRoyaltyTokens_parent_ip_id_not_registered(royalty_client):
-    parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-    child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False, autospec=True):
-        with pytest.raises(ValueError) as excinfo:
-            royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        assert str(excinfo.value) == f"The parent IP with id {parent_ip_id} is not registered."
-
-def test_collectRoyaltyTokens_royalty_vault_ip_id_not_registered(royalty_client):
-    parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-    child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', side_effect=[True, False], autospec=True):
-        with pytest.raises(ValueError) as excinfo:
-            royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        assert str(excinfo.value) == f"The IP with id {child_ip_id} is not registered."
-
-def test_collectRoyaltyTokens_royalty_vault_address_empty(royalty_client):
-    parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-    child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True, autospec=True), \
-         patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[], autospec=True):
-        with pytest.raises(ValueError) as excinfo:
-            royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        assert str(excinfo.value) == f"The royalty vault IP with id {child_ip_id} address is not set."
-
-def test_collectRoyaltyTokens_royalty_vault_address_zero(royalty_client):
-    parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-    child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True, autospec=True), \
-         patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, [child_ip_id], [1]], autospec=True):
-        with pytest.raises(ValueError) as excinfo:
-            royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        assert str(excinfo.value) == f"The royalty vault IP with id {child_ip_id} address is not set."
-        
-def test_collectRoyaltyTokens_success(royalty_client):
-    parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-    child_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-    tx_hash = "0x39f7ea8b04f383d7b60e1882f6bb7d94d3c9efa9251cef4543a1bb655faf21fb"
-    checksum_address = "0x344A37c7086Ee79E51894949119878112487eaD7"
-    royalty_tokens_collected = 10
-
-    # Mocking the expected behavior of the functions
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True), \
-         patch.object(royalty_client, '_getRoyaltyVaultAddress', return_value=checksum_address), \
-         patch.object(royalty_client, '_parseTxRoyaltyTokensCollectedEvent', return_value=royalty_tokens_collected), \
-         patch('story_protocol_python_sdk.abi.IpRoyaltyVaultImpl.IpRoyaltyVaultImpl_client.IpRoyaltyVaultImplClient.build_collectRoyaltyTokens_transaction', return_value={
-            'data': '0x',
-            'nonce': 0,
-            'gas': 2000000,
-            'gasPrice': Web3.to_wei('300', 'gwei')
-         }), \
-         patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr=tx_hash)), \
-         patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': [{'topics': [Web3.keccak(text="RoyaltyTokensCollected(address,uint256)").hex()], 'data': bytes.fromhex('000000000000000000000000000000000000000000000000000000000000000a')}]}):
-        
-        # Call the function being tested
-        result = royalty_client.collectRoyaltyTokens(parent_ip_id, child_ip_id)
-        
-        assert result['txHash'] == tx_hash[2:]
-        assert result['royaltyTokensCollected'] == royalty_tokens_collected
-        
-def test_snapshot_royaltyVaultIpId_error(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
-        child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-        
-        with pytest.raises(ValueError, match=f"The IP with id {child_ip_id} is not registered."):
-            royalty_client.snapshot(child_ip_id=child_ip_id)
-
-def test_snapshot_royaltyVaultAddress_error(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
-            child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {child_ip_id} address is not set."):
-                royalty_client.snapshot(child_ip_id=child_ip_id)
-
-def test_snapshot_success(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
-            with patch.object(royalty_client, '_parseTxSnapshotCompletedEvent', return_value=2):
-                with patch('story_protocol_python_sdk.abi.IpRoyaltyVaultImpl.IpRoyaltyVaultImpl_client.IpRoyaltyVaultImplClient.build_snapshot_transaction', return_value={
-                    'data': '0x',
-                    'nonce': 0,
-                    'gas': 2000000,
-                    'gasPrice': Web3.to_wei('300', 'gwei')
-                }):
-                    with patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr='0x471343c1ad3b358843b2079d8c5c1a0a5a86fe88382cdc67604b0209bbedf523')):
-                        with patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
-                            child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-
-                            response = royalty_client.snapshot(child_ip_id=child_ip_id)
-                            assert response is not None
-                            assert 'txHash' in response
-                            assert response['txHash'] == '471343c1ad3b358843b2079d8c5c1a0a5a86fe88382cdc67604b0209bbedf523'
-                            assert 'snapshotId' in response
-                            assert response['snapshotId'] == 2
-
-def test_claimableRevenue_royaltyVaultIpId_error(royalty_client):
+def test_claimable_revenue_royalty_vault_ip_id_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
         child_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
         account_address = account.address
-        snapshot_id = 1
         token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
 
         with pytest.raises(ValueError, match=f"The IP with id {child_ip_id} is not registered."):
-            royalty_client.claimableRevenue(child_ip_id, account_address, snapshot_id, token)
+            royalty_client.claimable_revenue(child_ip_id, account_address, token)
 
-def test_claimableRevenue_royaltyVaultAddress_error(royalty_client):
+def test_claimable_revenue_success(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
-            parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
-            account_address = account.address
-            snapshot_id = 1
-            token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
-
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {parent_ip_id} address is not set."):
-                royalty_client.claimableRevenue(parent_ip_id, account_address, snapshot_id, token)
-
-def test_claimableRevenue_success(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c", 1, ["0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"], [1]]):
+        with patch.object(royalty_client, 'get_royalty_vault_address', return_value="0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"):
             with patch('story_protocol_python_sdk.abi.IpRoyaltyVaultImpl.IpRoyaltyVaultImpl_client.IpRoyaltyVaultImplClient.claimableRevenue', return_value=0):
                 parent_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
                 account_address = account.address
-                snapshot_id = 1
                 token = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
 
-                response = royalty_client.claimableRevenue(parent_ip_id, account_address, snapshot_id, token)
+                response = royalty_client.claimable_revenue(parent_ip_id, account_address, token)
                 assert response == 0
 
-def test_claimRevenue_royaltyVaultIpId_error(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
-        parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-        ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
-        snapshot_ids = [1, 2]
-
-        with pytest.raises(ValueError, match=f"The IP with id {parent_ip_id} is not registered."):
-            royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
-
-def test_claimRevenue_royaltyVaultAddress_error(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x", 1, ["0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"], [1]]):
-            parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-            ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
-            snapshot_ids = [1, 2]
-
-            with pytest.raises(ValueError, match=f"The royalty vault IP with id {parent_ip_id} address is not set."):
-                royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
-
-def test_claimRevenue_success(royalty_client):
-    with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
-        with patch.object(royalty_client.royalty_policy_lap_client, 'getRoyaltyData', return_value=[True, "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7", 1, ["0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"], [1]]):
-            with patch.object(royalty_client, '_parseTxRevenueTokenClaimedEvent', return_value=0):
-                with patch('story_protocol_python_sdk.abi.IpRoyaltyVaultImpl.IpRoyaltyVaultImpl_client.IpRoyaltyVaultImplClient.build_claimRevenueBySnapshotBatch_transaction', return_value={
-                    'data': '0x',
-                    'nonce': 0,
-                    'gas': 2000000,
-                    'gasPrice': Web3.to_wei('300', 'gwei')
-                }):
-                    with patch('web3.eth.Eth.send_raw_transaction', return_value=Web3.to_bytes(hexstr='0x7065317271b179a2b4d47ff23b9b12ea50cdf668b892c8912cd7df71797b6561')):
-                        with patch('web3.eth.Eth.wait_for_transaction_receipt', return_value={'status': 1, 'logs': []}):
-                            parent_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
-                            ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
-                            snapshot_ids = [1, 2]
-
-                            response = royalty_client.claimRevenue(snapshot_ids, parent_ip_id, ERC20)
-                            assert response is not None
-                            assert 'txHash' in response
-                            assert response['txHash'] == '7065317271b179a2b4d47ff23b9b12ea50cdf668b892c8912cd7df71797b6561'
-                            assert 'claimableToken' in response
-                            assert response['claimableToken'] == 0
-
-def test_payRoyaltyOnBehalf_receiverIpId_error(royalty_client):
+def test_pay_royalty_on_behalf_receiver_ip_id_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=False):
         receiver_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
         payer_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
@@ -214,9 +59,9 @@ def test_payRoyaltyOnBehalf_receiverIpId_error(royalty_client):
         amount = 1
 
         with pytest.raises(ValueError, match=f"The receiver IP with id {receiver_ip_id} is not registered."):
-            royalty_client.payRoyaltyOnBehalf(receiver_ip_id, payer_ip_id, ERC20, amount)
+            royalty_client.pay_royalty_on_behalf(receiver_ip_id, payer_ip_id, ERC20, amount)
 
-def test_payRoyaltyOnBehalf_payerIpId_error(royalty_client):
+def test_pay_royalty_on_behalf_payer_ip_id_error(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', side_effect=[True, False]):
         receiver_ip_id = "0xA34611b0E11Bba2b11c69864f7D36aC83D862A9c"
         payer_ip_id = "0x9C098DF37b2324aaC8792dDc7BcEF7Bb0057A9C7"
@@ -224,9 +69,9 @@ def test_payRoyaltyOnBehalf_payerIpId_error(royalty_client):
         amount = 1
 
         with pytest.raises(ValueError, match=f"The payer IP with id {payer_ip_id} is not registered."):
-            royalty_client.payRoyaltyOnBehalf(receiver_ip_id, payer_ip_id, ERC20, amount)
+            royalty_client.pay_royalty_on_behalf(receiver_ip_id, payer_ip_id, ERC20, amount)
 
-def test_payRoyaltyOnBehalf_success(royalty_client):
+def test_pay_royalty_on_behalf_success(royalty_client):
     with patch.object(royalty_client.ip_asset_registry_client, 'isRegistered', return_value=True):
         with patch('story_protocol_python_sdk.abi.RoyaltyModule.RoyaltyModule_client.RoyaltyModuleClient.build_payRoyaltyOnBehalf_transaction', return_value={
             'data': '0x',
@@ -241,7 +86,7 @@ def test_payRoyaltyOnBehalf_success(royalty_client):
                     ERC20 = "0xB132A6B7AE652c974EE1557A3521D53d18F6739f"
                     amount = 1
 
-                    response = royalty_client.payRoyaltyOnBehalf(receiver_ip_id, payer_ip_id, ERC20, amount, tx_options={'wait_for_transaction': True})
+                    response = royalty_client.pay_royalty_on_behalf(receiver_ip_id, payer_ip_id, ERC20, amount, tx_options={'wait_for_transaction': True})
                     assert response is not None
-                    assert 'txHash' in response
-                    assert response['txHash'] == 'badf64f2c220e27407c4d2ccbc772fb72c7dc590ac25000dc316e4dc519fbfa2'
+                    assert 'tx_hash' in response
+                    assert response['tx_hash'] == 'badf64f2c220e27407c4d2ccbc772fb72c7dc590ac25000dc316e4dc519fbfa2'


### PR DESCRIPTION
## Description
- Updated existing unit tests for ip account, ip asset, license, and royalty modules
- Removed deprecated functions from unit tests

## Test Plan 
- Ensure all updated unit tests pass

## Related Issue
n/a

## Notes
- This does not include full coverage for these models but unit tests will be continued to be added and updated moving forward