### PR TITLE
Debugging Groups Module Integration Tests

### DIFF
--- a/tests/integration/test_integration_group.py
+++ b/tests/integration/test_integration_group.py
@@ -500,7 +500,7 @@ class TestCollectRoyaltyAndClaimReward:
             ancestor_ip_id=group_ip_id,
             token=MockERC20
         )
-        
+
         return {
             'group_ip_id': group_ip_id,
             'ip_ids': ip_ids
@@ -523,6 +523,7 @@ class TestCollectRoyaltyAndClaimReward:
         assert len(response['tx_hash']) > 0
         
         assert 'collected_royalties' in response
+
         assert len(response['collected_royalties']) > 0
         assert response['collected_royalties'][0]['amount'] == 20
         

--- a/tests/integration/test_integration_ip_account.py
+++ b/tests/integration/test_integration_ip_account.py
@@ -420,10 +420,11 @@ class TestSetIpMetadata:
             nft_contract=MockERC721,
             token_id=token_id
         )
-        ip_id = register_response['ipId']
+        print(register_response)
+        ip_id = register_response['ip_id']
 
         deadline = get_block_timestamp(web3) + 100
-        state = story_client.IPAccount.getIpAccountNonce(ip_id)        
+        state = story_client.IPAccount.get_ip_account_nonce(ip_id)        
         data = "0x"
         
         execute_data = story_client.IPAccount.ip_account_client.contract.encode_abi(
@@ -472,7 +473,7 @@ class TestSetIpMetadata:
         wrong_signer = "0x1234567890123456789012345678901234567890"
         
         with pytest.raises(Exception) as exc_info:
-            story_client.IPAccount.executeWithSig(
+            story_client.IPAccount.execute_with_sig(
                 ip_id=ip_id,
                 to=story_client.IPAccount.access_controller_client.contract.address,
                 value=0,
@@ -509,10 +510,10 @@ class TestSetIpMetadata:
             nft_contract=MockERC721,
             token_id=token_id
         )
-        ip_id = register_response['ipId']
+        ip_id = register_response['ip_id']
         
         with pytest.raises(ValueError) as exc_info:
-            story_client.IPAccount.transferERC20(
+            story_client.IPAccount.transfer_erc20(
                 ip_id=ip_id,
                 tokens=[
                     {

--- a/tests/integration/test_integration_ip_account.py
+++ b/tests/integration/test_integration_ip_account.py
@@ -420,7 +420,6 @@ class TestSetIpMetadata:
             nft_contract=MockERC721,
             token_id=token_id
         )
-        print(register_response)
         ip_id = register_response['ip_id']
 
         deadline = get_block_timestamp(web3) + 100

--- a/tests/integration/test_integration_nft_client.py
+++ b/tests/integration/test_integration_nft_client.py
@@ -113,7 +113,7 @@ class TestErrorCases:
     def test_invalid_mint_fee_values(self, story_client):
         """Test with invalid mint fee values"""
         with pytest.raises(ValueError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 is_public_minting=True,
@@ -127,7 +127,7 @@ class TestErrorCases:
         
         try:
             huge_mint_fee = 2**256 - 1  # Max uint256 value
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 is_public_minting=True,
@@ -145,7 +145,7 @@ class TestErrorCases:
         """Test omitting required parameters"""
         
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 # name is omitted
                 symbol="TEST",
                 is_public_minting=True,
@@ -155,7 +155,7 @@ class TestErrorCases:
             )
         
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 # symbol is omitted
                 is_public_minting=True,
@@ -165,7 +165,7 @@ class TestErrorCases:
             )
         
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 # is_public_minting is omitted
@@ -175,7 +175,7 @@ class TestErrorCases:
             )
     
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 is_public_minting=True,
@@ -185,7 +185,7 @@ class TestErrorCases:
             )
         
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 is_public_minting=True,
@@ -195,7 +195,7 @@ class TestErrorCases:
             )
         
         with pytest.raises(TypeError) as exc_info:
-            story_client.NFTClient.createNFTCollection(
+            story_client.NFTClient.create_nft_collection(
                 name="test-collection",
                 symbol="TEST",
                 is_public_minting=True,
@@ -209,7 +209,7 @@ class TestErrorCases:
         
         different_owner = "0x1234567890123456789012345678901234567890"
         
-        response = story_client.NFTClient.createNFTCollection(
+        response = story_client.NFTClient.create_nft_collection(
             name="test-collection",
             symbol="TEST",
             is_public_minting=True,
@@ -220,8 +220,8 @@ class TestErrorCases:
         )
         
         assert response is not None
-        assert 'nftContract' in response
-        assert Web3.is_address(response['nftContract'])
+        assert 'nft_contract' in response
+        assert Web3.is_address(response['nft_contract'])
 
 class TestMintFee:
     """Tests for mint fee functionality in NFT collections"""


### PR DESCRIPTION
## Description
This PR addresses the following issues:

* It fixes the issues with the `collect_and_distribute_group_royalties` call. These were caused by the use of a incorrect version of the `CollectedRoyaltiesToGroupPool` and `RoyaltyPaid` events signatures in the `Group` module. 
* It updates existing integration tests to comply with the existing naming convention.