### PR TITLE
Fix permission unit tests

### DIFF
--- a/tests/unit/resources/test_permission.py
+++ b/tests/unit/resources/test_permission.py
@@ -36,17 +36,17 @@ def permission():
 
 
 def test_unregistered_ip_account(permission):
-    with patch.object(permission, '_is_registered', return_value=False):
-        with pytest.raises(ValueError, match="The IP account with id 0x0000000000000000000000000000000000000000 is not registered."):
-            permission.setPermission(ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, 1)
+    with patch.object(permission.ip_asset_registry_client, 'isRegistered', return_value=False):
+        with pytest.raises(Exception, match="IP id with 0x0000000000000000000000000000000000000000 is not registered."):
+            permission.set_permission(ZERO_ADDRESS, ZERO_ADDRESS, ZERO_ADDRESS, 1)
 
 def test_invalid_signer_address(permission):
-    with pytest.raises(ValueError, match="The address 0xInvalidAddress that can call 'to' on behalf of the 'ip_asset' is not a valid address."):
-        permission.setPermission(ZERO_ADDRESS, "0xInvalidAddress", ZERO_ADDRESS, "0x11111111111111111111111111111")
+    with pytest.raises(Exception, match=" Invalid address: 0xInvalidAddress"):
+        permission.set_permission(ZERO_ADDRESS, "0xInvalidAddress", ZERO_ADDRESS, "0x11111111111111111111111111111")
 
 def test_invalid_to_address(permission):
-    with pytest.raises(ValueError, match="The recipient of the transaction 0xInvalidAddress is not a valid address."):
-        permission.setPermission(ZERO_ADDRESS, ZERO_ADDRESS, "0xInvalidAddress", "0x11111111111111111111111111111")
+    with pytest.raises(Exception, match="Invalid address: 0xInvalidAddress."):
+        permission.set_permission(ZERO_ADDRESS, ZERO_ADDRESS, "0xInvalidAddress", "0x11111111111111111111111111111")
 
 def test_successful_transaction(permission):
     ip_asset = "0x587AE719cACC8cC34188D9648d67CF885bE10558"
@@ -56,10 +56,10 @@ def test_successful_transaction(permission):
     permission_level = 1
     tx_hash = "0x0c0cce07beb64ccfbdd59da111f23084ab7c9e96a951f7381af49e792d014c04"
     
-    with patch.object(permission, '_is_registered', return_value=True), \
-         patch('story_protocol_python_sdk.resources.IPAccount.IPAccount.execute', return_value={'txHash': tx_hash}):
-        response = permission.setPermission(ip_asset, signer, to, permission_level, func)
-        assert response['txHash'] == tx_hash
+    with patch.object(permission.ip_asset_registry_client, 'isRegistered', return_value=True), \
+         patch.object(permission.ip_account, 'execute', return_value={'tx_hash': tx_hash}):
+        response = permission.set_permission(ip_asset, signer, to, permission_level, func)
+        assert response['tx_hash'] == tx_hash
 
 def test_transaction_request_fails(permission):
     ip_asset = "0x587AE719cACC8cC34188D9648d67CF885bE10558"
@@ -68,8 +68,7 @@ def test_transaction_request_fails(permission):
     func = "0x00000000"
     permission_level = 1
     
-    with patch.object(permission, '_is_registered', return_value=True), \
-         patch('story_protocol_python_sdk.resources.IPAccount.IPAccount.execute', side_effect=Exception("Transaction failed")):
-        with pytest.raises(Exception) as excinfo:
-            permission.setPermission(ip_asset, signer, to, permission_level, func)
-        assert str(excinfo.value) == "Transaction failed"
+    with patch.object(permission.ip_asset_registry_client, 'isRegistered', return_value=True), \
+         patch.object(permission.ip_account, 'execute', side_effect=Exception("Transaction failed")):
+        with pytest.raises(Exception, match="Transaction failed"):
+            permission.set_permission(ip_asset, signer, to, permission_level, func)


### PR DESCRIPTION
# Description
Fix `Permission` module unit tests

- Changed `setPermission` to `set_permission` for consistency.
- Updated exception types and messages in tests for unregistered IP accounts, invalid signer addresses, and invalid recipient addresses.
- Enhanced test coverage for successful transactions and failure scenarios with improved error handling.

