### PR TITLE
feat: add register_pil_terms_and_attach method to IPAsset class

### DIFF
--- a/src/story_protocol_python_sdk/types/resource/IPAsset.py
+++ b/src/story_protocol_python_sdk/types/resource/IPAsset.py
@@ -16,3 +16,16 @@ class RegistrationResponse(TypedDict):
     ip_id: Address
     tx_hash: HexStr
     token_id: Optional[int]
+
+
+class RegisterPILTermsAndAttachResponse(TypedDict):
+    """
+    Response structure for Programmable IP License Terms registration and attachment operations.
+
+    Attributes:
+        tx_hash: The transaction hash of the registration transaction
+        license_terms_ids: The IDs of the registered license terms
+    """
+
+    tx_hash: HexStr
+    license_terms_ids: list[int]

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -789,7 +789,7 @@ class TestMintAndRegisterIpAndMakeDerivativeWithLicenseTokens:
                 nft_metadata_hash=web3.keccak(text="custom-value-metadata"),
             ),
             recipient=account_2.address,
-            allow_duplicates=False,
+            allow_duplicates=True,
         )
         assert response is not None
         assert isinstance(response["tx_hash"], str)

--- a/tests/integration/test_integration_ip_asset.py
+++ b/tests/integration/test_integration_ip_asset.py
@@ -795,3 +795,82 @@ class TestMintAndRegisterIpAndMakeDerivativeWithLicenseTokens:
         assert isinstance(response["tx_hash"], str)
         assert isinstance(response["ip_id"], str)
         assert isinstance(response["token_id"], int)
+
+
+class TestRegisterPilTermsAndAttach:
+    def test_successful_registration(
+        self,
+        story_client: StoryClient,
+        parent_ip_and_license_terms,
+    ):
+        response = story_client.IPAsset.register_pil_terms_and_attach(
+            ip_id=parent_ip_and_license_terms["parent_ip_id"],
+            license_terms_data=[
+                {
+                    "terms": {
+                        "transferable": True,
+                        "royalty_policy": ROYALTY_POLICY,
+                        "default_minting_fee": 1,
+                        "expiration": 0,
+                        "commercial_use": True,
+                        "commercial_attribution": False,
+                        "commercializer_checker": ZERO_ADDRESS,
+                        "commercializer_checker_data": ZERO_ADDRESS,
+                        "commercial_rev_share": 90,
+                        "commercial_rev_ceiling": 0,
+                        "derivatives_allowed": True,
+                        "derivatives_attribution": True,
+                        "derivatives_approval": False,
+                        "derivatives_reciprocal": True,
+                        "derivative_rev_ceiling": 0,
+                        "currency": MockERC20,
+                        "uri": "",
+                    },
+                    "licensing_config": {
+                        "is_set": True,
+                        "minting_fee": 1,
+                        "hook_data": "",
+                        "licensing_hook": ZERO_ADDRESS,
+                        "commercial_rev_share": 90,
+                        "disabled": False,
+                        "expect_minimum_group_reward_share": 0,
+                        "expect_group_reward_pool": ZERO_ADDRESS,
+                    },
+                },
+                {
+                    "terms": {
+                        "transferable": True,
+                        "royalty_policy": ROYALTY_POLICY,
+                        "default_minting_fee": 10,
+                        "expiration": 0,
+                        "commercial_use": True,
+                        "commercial_attribution": False,
+                        "commercializer_checker": ZERO_ADDRESS,
+                        "commercializer_checker_data": ZERO_ADDRESS,
+                        "commercial_rev_share": 10,
+                        "commercial_rev_ceiling": 0,
+                        "derivatives_allowed": True,
+                        "derivatives_attribution": True,
+                        "derivatives_approval": False,
+                        "derivatives_reciprocal": True,
+                        "derivative_rev_ceiling": 0,
+                        "currency": MockERC20,
+                        "uri": "",
+                    },
+                    "licensing_config": {
+                        "is_set": False,
+                        "minting_fee": 1,
+                        "hook_data": "",
+                        "licensing_hook": ZERO_ADDRESS,
+                        "commercial_rev_share": 90,
+                        "disabled": False,
+                        "expect_minimum_group_reward_share": 0,
+                        "expect_group_reward_pool": ZERO_ADDRESS,
+                    },
+                },
+            ],
+            deadline=10000,
+        )
+        assert response is not None
+        assert isinstance(response["tx_hash"], str)
+        assert len(response["license_terms_ids"]) == 2

--- a/tests/integration/test_integration_wip.py
+++ b/tests/integration/test_integration_wip.py
@@ -16,7 +16,7 @@ wallet_address_2_str: str = wallet_address_2
 class TestWIPDeposit:
     def test_deposit(self, story_client: StoryClient):
         """Test depositing IP to WIP"""
-        ip_amt = web3.to_wei(1, "ether")  # or Web3.to_wei("0.01", 'ether')
+        ip_amt = web3.to_wei(0.000001, "ether")  # or Web3.to_wei("0.01", 'ether')
 
         # Get balances before deposit
         balance_before = story_client.get_wallet_balance()

--- a/tests/integration/test_integration_wip.py
+++ b/tests/integration/test_integration_wip.py
@@ -16,7 +16,7 @@ wallet_address_2_str: str = wallet_address_2
 class TestWIPDeposit:
     def test_deposit(self, story_client: StoryClient):
         """Test depositing IP to WIP"""
-        ip_amt = web3.to_wei(0.000001, "ether")  # or Web3.to_wei("0.01", 'ether')
+        ip_amt = web3.to_wei(0.000001, "ether")
 
         # Get balances before deposit
         balance_before = story_client.get_wallet_balance()

--- a/tests/unit/fixtures/data.py
+++ b/tests/unit/fixtures/data.py
@@ -21,7 +21,6 @@ LICENSE_TERMS = {
     "derivative_rev_ceiling": 100,
     "uri": "https://example.com",
     "transferable": True,
-    "expect_minimum_group_reward_share": 10,
 }
 
 LICENSING_CONFIG = {


### PR DESCRIPTION
## Description
- Add `register_pil_terms_and_attach` method to IPAsset class
- Introduced integration and unit tests for the new `register_pil_terms_and_attach` method
- update `deposit` amount in WIP integration test to a smaller value to reduce gas fee

## Test Plan

<img width="1435" height="342" alt="image" src="https://github.com/user-attachments/assets/893de357-5608-4f21-a3be-1cc95e67993b" />
